### PR TITLE
Adding missing lambda operators to JS/TS examples

### DIFF
--- a/web/src/pages/concepts/from-js.loon
+++ b/web/src/pages/concepts/from-js.loon
@@ -82,13 +82,13 @@
         "function add(a, b) \{ return a + b \}"
         "[fn add [a b] [+ a b]]"]
       [doc-row
-        "(x) x * 2"
+        "(x) => x * 2"
         "[fn [x] [* x 2]]"]
       [doc-row
-        "arr.map(x x * 2)"
+        "arr.map(x => x * 2)"
         "[map [fn [x] [* x 2]] arr]"]
       [doc-row
-        "arr.filter(x x > 2)"
+        "arr.filter(x => x > 2)"
         "[filter [fn [x] [> x 2]] arr]"]
       [doc-row
         "x > 0 ? \"pos\" : \"neg\""


### PR DESCRIPTION
Fixes #3 by correcting the missing lambda operators in the JS/TS examples