### PR TITLE
feat: add document_formatting_provider to lsp

### DIFF
--- a/crates/loon-lsp/src/lib.rs
+++ b/crates/loon-lsp/src/lib.rs
@@ -1,4 +1,4 @@
-use tower_lsp::jsonrpc::Result;
+use tower_lsp::jsonrpc::{Error as JsonrpcError, ErrorCode as JsonrpcErrorCode, Result};
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
@@ -76,6 +76,7 @@ impl LanguageServer for LoonLanguageServer {
                     trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
                     ..Default::default()
                 }),
+                document_formatting_provider: Some(OneOf::Left(true)),
                 inlay_hint_provider: Some(OneOf::Left(true)),
                 ..Default::default()
             },
@@ -115,6 +116,46 @@ impl LanguageServer for LoonLanguageServer {
         self.documents.remove(&uri);
         // Clear diagnostics
         self.client.publish_diagnostics(uri, vec![], None).await;
+    }
+
+    async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
+        let uri = &params.text_document.uri;
+
+        let Some(doc) = self.documents.get(uri) else {
+            return Ok(None);
+        };
+
+        let source = doc.rope.to_string();
+
+        let Ok(exprs) = loon_lang::parser::parse(&source) else {
+            return Err(JsonrpcError {
+                code: JsonrpcErrorCode::InternalError,
+                message: "failed to parse source".into(),
+                data: None,
+            });
+        };
+
+        let formatted = loon_lang::fmt::format_program(&exprs);
+
+        if formatted == source {
+            return Ok(None);
+        }
+
+        let end = Position {
+            line: doc.rope.len_lines() as u32,
+            character: 0,
+        };
+
+        Ok(Some(vec![TextEdit {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end,
+            },
+            new_text: formatted,
+        }]))
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {

--- a/crates/loon-lsp/src/lib.rs
+++ b/crates/loon-lsp/src/lib.rs
@@ -1,4 +1,4 @@
-use tower_lsp::jsonrpc::{Error as JsonrpcError, ErrorCode as JsonrpcErrorCode, Result};
+use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
@@ -125,37 +125,10 @@ impl LanguageServer for LoonLanguageServer {
             return Ok(None);
         };
 
-        let source = doc.rope.to_string();
-
-        let Ok(exprs) = loon_lang::parser::parse(&source) else {
-            return Err(JsonrpcError {
-                code: JsonrpcErrorCode::InternalError,
-                message: "failed to parse source".into(),
-                data: None,
-            });
-        };
-
-        let formatted = loon_lang::fmt::format_program(&exprs);
-
-        if formatted == source {
-            return Ok(None);
-        }
-
-        let end = Position {
-            line: doc.rope.len_lines() as u32,
-            character: 0,
-        };
-
-        Ok(Some(vec![TextEdit {
-            range: Range {
-                start: Position {
-                    line: 0,
-                    character: 0,
-                },
-                end,
-            },
-            new_text: formatted,
-        }]))
+        Ok(formatting_edits(
+            &doc.rope.to_string(),
+            doc.rope.len_lines() as u32,
+        ))
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
@@ -323,6 +296,33 @@ fn classify_completion_kind(ty: &Type) -> CompletionItemKind {
         Type::Con(_, _) => CompletionItemKind::ENUM,
         _ => CompletionItemKind::VARIABLE,
     }
+}
+
+/// Compute the formatting edit for a document. Returns `None` when the source
+/// is already formatted or cannot be parsed — an unparseable buffer (e.g. an
+/// in-progress edit saved with format-on-save) should be a silent no-op, not an
+/// error popup.
+fn formatting_edits(source: &str, len_lines: u32) -> Option<Vec<TextEdit>> {
+    let exprs = loon_lang::parser::parse(source).ok()?;
+    let formatted = loon_lang::fmt::format_program(&exprs);
+
+    if formatted == source {
+        return None;
+    }
+
+    Some(vec![TextEdit {
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: len_lines,
+                character: 0,
+            },
+        },
+        new_text: formatted,
+    }])
 }
 
 /// Recursively collect inlay hints for let bindings and defn params.
@@ -508,6 +508,28 @@ mod tests {
             .filter(|r| r.name == "add")
             .collect();
         assert!(!add_refs.is_empty(), "should have references to 'add'");
+    }
+
+    #[test]
+    fn formatting_edits_reformats_unformatted_source() {
+        let src = "[let   x    42]";
+        let edits = formatting_edits(src, 1).expect("unformatted source should yield an edit");
+        assert_eq!(edits.len(), 1);
+        assert_ne!(edits[0].new_text, src);
+        // The replacement must be itself stable (idempotent formatter output).
+        assert!(formatting_edits(&edits[0].new_text, 1).is_none());
+    }
+
+    #[test]
+    fn formatting_edits_noop_when_already_formatted() {
+        let src = loon_lang::fmt::format_program(&loon_lang::parser::parse("[let x 42]").unwrap());
+        assert!(formatting_edits(&src, 1).is_none());
+    }
+
+    #[test]
+    fn formatting_edits_silent_on_parse_error() {
+        // Unparseable buffer must be a no-op, not an error popup.
+        assert!(formatting_edits("[let x", 1).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Hi, first off loon is really cool and checks a huge number of boxes for me so thanks for you work so far!

I'm not sure if you're open to contributions so feel free to close this if you aren't.

But when I was looking at the docs and trying to set up auto-format in neovim I would get the following error:

```
method textDocument/formatting is not supported by any of the servers registered for the current buffer
```

After some poking around at tower-lsp it seemed fairly trivial to add so here it is. Let me know if you'd need any changes to merge.

Thanks!