### PR TITLE
Sandbox compile-time effects in procedural macros

### DIFF
--- a/crates/loon-lang/src/interp/builtins.rs
+++ b/crates/loon-lang/src/interp/builtins.rs
@@ -256,6 +256,9 @@ pub fn register_builtins(env: &mut Env) {
     });
 
     builtin!(env, "println", |_, args: &[Value]| {
+        if let Some(msg) = super::compile_sandbox_denial("IO", "println") {
+            return Err(err(msg));
+        }
         let parts: Vec<String> = args.iter().map(|v| v.display_str()).collect();
         let line = parts.join(" ");
         let captured = PRINT_BUF.with(|buf| {
@@ -274,6 +277,9 @@ pub fn register_builtins(env: &mut Env) {
     });
 
     builtin!(env, "print", |_, args: &[Value]| {
+        if let Some(msg) = super::compile_sandbox_denial("IO", "println") {
+            return Err(err(msg));
+        }
         let parts: Vec<String> = args.iter().map(|v| v.display_str()).collect();
         let text = parts.join(" ");
         let captured = PRINT_BUF.with(|buf| {

--- a/crates/loon-lang/src/interp/mod.rs
+++ b/crates/loon-lang/src/interp/mod.rs
@@ -31,6 +31,11 @@ thread_local! {
     static CURRENT_MODULE: RefCell<Option<String>> = const { RefCell::new(None) };
     /// Effect grants loaded from manifest (None = no enforcement)
     static EFFECT_GRANTS: RefCell<Option<crate::pkg::capability::EffectGrants>> = const { RefCell::new(None) };
+    /// Compile-time effect sandbox for procedural macro bodies.
+    /// `None` = not expanding a macro (runtime / unrestricted).
+    /// `Some(allowed)` = inside a procedural macro; only the listed effect
+    /// categories ("IO"/"Net"/"Env"/"Print") may be performed. Default-deny.
+    static COMPILE_SANDBOX: RefCell<Option<std::collections::HashSet<String>>> = const { RefCell::new(None) };
 }
 
 #[derive(Debug, Clone)]
@@ -100,6 +105,12 @@ pub fn err_at(msg: impl Into<String>, span: Span) -> InterpError {
 
 /// Try to handle an effect with a built-in handler (for IO at the top level).
 pub(crate) fn try_builtin_handler(performed: &PerformedEffect) -> Option<IResult> {
+    // Compile-time sandbox: deny effectful ops a procedural macro did not
+    // declare. This is the single chokepoint for IO/Net/Env/Process effects,
+    // so gating here covers every dependency-macro execution path.
+    if let Some(msg) = compile_sandbox_denial(&performed.effect, &performed.operation) {
+        return Some(Err(err(msg)));
+    }
     match (performed.effect.as_str(), performed.operation.as_str()) {
         ("IO", "println") => {
             let parts: Vec<String> = performed.args.iter().map(|v| v.display_str()).collect();
@@ -623,6 +634,67 @@ pub fn set_effect_grants(grants: crate::pkg::capability::EffectGrants) {
 /// Set the current module for grant checking. None = root (unrestricted).
 pub fn set_current_module(module: Option<String>) {
     CURRENT_MODULE.with(|m| *m.borrow_mut() = module);
+}
+
+/// Enter/leave the compile-time macro sandbox. Returns the previous value so
+/// callers can restore it (nested procedural macro expansion).
+pub fn swap_compile_sandbox(
+    sandbox: Option<std::collections::HashSet<String>>,
+) -> Option<std::collections::HashSet<String>> {
+    COMPILE_SANDBOX.with(|s| s.replace(sandbox))
+}
+
+/// Classify an effectful `(effect, op)` pair into a compile-time effect
+/// category, or `None` if the operation is pure/benign (cannot exfiltrate,
+/// tamper, or escape the sandbox: json codec, hashing, clock, uuid, sleep).
+fn compile_effect_category(effect: &str, op: &str) -> Option<&'static str> {
+    match (effect, op) {
+        // Stdout — benign but declared so the model stays coherent.
+        ("IO", "println") => Some("Print"),
+        // Filesystem + process: read/write/enumerate/mutate the host.
+        (
+            "IO",
+            "read-file" | "write-file" | "list-dir" | "copy-file" | "mkdir" | "delete-file"
+            | "read-line" | "file-exists?" | "mtime",
+        ) => Some("IO"),
+        ("Process", "exec" | "exit") => Some("IO"),
+        // Environment read.
+        ("Process", "env" | "args") => Some("Env"),
+        // Network.
+        ("Net", _) => Some("Net"),
+        _ => None,
+    }
+}
+
+/// If a compile-time macro sandbox is active, returns `Some(error)` when the
+/// given effectful op is not in the declared allow-set. `None` otherwise
+/// (no sandbox, or operation permitted/pure).
+pub(crate) fn compile_sandbox_denial(effect: &str, op: &str) -> Option<String> {
+    COMPILE_SANDBOX.with(|s| {
+        let guard = s.borrow();
+        let allowed = guard.as_ref()?;
+        // Thread spawn is always denied inside the sandbox: a freshly spawned
+        // OS thread does not inherit COMPILE_SANDBOX, so allowing it would let
+        // a macro escape the sandbox by doing its IO on another thread.
+        if effect == "Async" && op == "spawn" {
+            return Some(
+                "compile-time `Async.spawn` is not permitted: a procedural macro may not \
+                 spawn threads during build (sandbox-escape vector)."
+                    .to_string(),
+            );
+        }
+        let category = compile_effect_category(effect, op)?;
+        if allowed.contains(category) {
+            None
+        } else {
+            Some(format!(
+                "compile-time effect `{category}` ({effect}.{op}) used by a procedural macro \
+                 that did not declare it. A macro may only perform compile-time effects it \
+                 declares: `[macro name [..] #{{{category}}} ..]`. This guard blocks \
+                 dependency macros from running arbitrary IO/Net/Env code during build."
+            ))
+        }
+    })
 }
 
 pub fn get_effect_log() -> Vec<EffectEntry> {

--- a/crates/loon-lang/src/macros/mod.rs
+++ b/crates/loon-lang/src/macros/mod.rs
@@ -513,9 +513,6 @@ impl MacroExpander {
         bindings: &HashMap<String, Vec<Expr>>,
         call_span: Span,
     ) -> Result<Expr, String> {
-        // Check compile-time effects
-        self.check_compile_effects(mac)?;
-
         // Build a mini program that evaluates the macro body with bindings
         // The approach: create let bindings for each macro param, then evaluate body
         let mut program = Vec::new();
@@ -548,19 +545,38 @@ impl MacroExpander {
         // Add the macro body
         program.push(mac.body.clone());
 
+        // Enter the compile-time effect sandbox. A procedural macro body runs
+        // arbitrary Loon code via the interpreter at *build time*; without this
+        // a malicious dependency macro could read ~/.ssh, spawn processes, or
+        // exfiltrate over the network during `loon build`. Default-deny: only
+        // the effect categories the macro explicitly declared via `#{...}` are
+        // permitted. Save/restore the prior value so nested procedural macro
+        // expansion composes correctly.
+        let allowed: std::collections::HashSet<String> = mac
+            .compile_effects
+            .iter()
+            .map(|e| {
+                match e {
+                    CompileEffect::IO => "IO",
+                    CompileEffect::Net => "Net",
+                    CompileEffect::Env => "Env",
+                    CompileEffect::Print => "Print",
+                }
+                .to_string()
+            })
+            .collect();
+        let prev_sandbox = interp::swap_compile_sandbox(Some(allowed));
+
         // Evaluate the program using the interpreter
-        let result = interp::eval_program(&program)
+        let eval_result = interp::eval_program(&program);
+
+        interp::swap_compile_sandbox(prev_sandbox);
+
+        let result = eval_result
             .map_err(|e| format!("procedural macro '{}' failed: {}", mac.name, e.message))?;
 
         // Convert the result value back to an AST Expr
         ast_value_to_expr(&result, call_span)
-    }
-
-    fn check_compile_effects(&self, _mac: &MacroDef) -> Result<(), String> {
-        // For now, we just record what's declared. Full enforcement happens
-        // when compile-time builtins are called.
-        // Pure macros (no declared effects) should not call IO/Net/etc builtins.
-        Ok(())
     }
 
     /// Check if a name is a registered macro.
@@ -917,6 +933,95 @@ mod tests {
         let s = format!("{}", expanded[0]);
         // when2 expands to when, which expands to if
         assert!(s.contains("if"), "expected 'if' in: {s}");
+    }
+
+    #[test]
+    fn procedural_macro_undeclared_effect_denied() {
+        // A procedural macro that performs an effect at expansion time without
+        // declaring it must be hard-denied — this is the supply-chain guard.
+        let src = r#"
+            [macro snitch [x]
+              [do
+                [Process.env "HOME"]
+                {:kind :int :value 1}]]
+            [snitch 0]
+        "#;
+        let exprs = parse(src).unwrap();
+        let mut expander = MacroExpander::new();
+        let e = expander.expand_program(&exprs).unwrap_err();
+        assert!(e.contains("compile-time effect `Env`"), "got: {e}");
+        assert!(e.contains("did not declare it"), "got: {e}");
+    }
+
+    #[test]
+    fn procedural_macro_declared_effect_allowed() {
+        // Same macro, but it declares `#{Env}` — expansion is permitted.
+        let src = r#"
+            [macro envy [x] #{Env}
+              [do
+                [Process.env "HOME"]
+                {:kind :int :value 7}]]
+            [envy 0]
+        "#;
+        let exprs = parse(src).unwrap();
+        let mut expander = MacroExpander::new();
+        let expanded = expander.expand_program(&exprs).unwrap();
+        assert_eq!(expanded.len(), 1);
+        assert!(
+            matches!(expanded[0].kind, ExprKind::Int(7)),
+            "expected Int(7), got: {}",
+            expanded[0]
+        );
+    }
+
+    #[test]
+    fn procedural_macro_undeclared_when_other_effect_declared() {
+        // Declaring `#{Print}` must not implicitly grant `Env` — categories
+        // are independent (default-deny per category).
+        let src = r#"
+            [macro sneaky [x] #{Print}
+              [do
+                [Process.env "HOME"]
+                {:kind :int :value 1}]]
+            [sneaky 0]
+        "#;
+        let exprs = parse(src).unwrap();
+        let mut expander = MacroExpander::new();
+        let e = expander.expand_program(&exprs).unwrap_err();
+        assert!(e.contains("compile-time effect `Env`"), "got: {e}");
+    }
+
+    #[test]
+    fn procedural_macro_thread_spawn_always_denied() {
+        // Async.spawn is a sandbox-escape vector and is denied even though the
+        // macro declares IO.
+        let src = r#"
+            [macro forker [x] #{IO}
+              [do
+                [Async.spawn [fn [] 1]]
+                {:kind :int :value 1}]]
+            [forker 0]
+        "#;
+        let exprs = parse(src).unwrap();
+        let mut expander = MacroExpander::new();
+        let e = expander.expand_program(&exprs).unwrap_err();
+        assert!(e.contains("Async.spawn"), "got: {e}");
+        assert!(e.contains("not permitted"), "got: {e}");
+    }
+
+    #[test]
+    fn runtime_effects_not_sandboxed() {
+        // Regression guard: the compile-time sandbox must not leak into normal
+        // runtime execution. A plain program performing an effect is fine.
+        let exprs = parse(r#"[Process.env "HOME"]"#).unwrap();
+        let mut expander = MacroExpander::new();
+        let expanded = expander.expand_program(&exprs).unwrap();
+        let r = crate::interp::eval_program(&expanded);
+        assert!(
+            r.is_ok(),
+            "runtime effect wrongly sandboxed: {:?}",
+            r.err().map(|e| e.message)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the macro supply-chain vector: procedural macro bodies run arbitrary Loon code via the interpreter at **build time**, and the declared `#{IO Net Env Print}` effects were parsed but never enforced (`check_compile_effects` was a documented no-op). A malicious dependency macro could read `~/.ssh`, spawn processes, or exfiltrate over the network during `loon build` — the supply-chain equivalent of an npm `postinstall` script.

This enforces **default-deny on compile-time effects**.

## What changed

- **`COMPILE_SANDBOX` thread-local** (`interp/mod.rs`) — `None` at runtime (unrestricted, unchanged behavior), `Some(allowed)` only while a procedural macro body evaluates.
- **Single chokepoint gate** — `compile_sandbox_denial` runs at the top of `try_builtin_handler`, through which every IO/Net/Env/Process effect flows. Plain `print`/`println` builtins are gated too. Pure ops (json codec, hashing, clock, uuid, sleep) are intentionally not gated.
- **Enforcement in `expand_procedural`** (`macros/mod.rs`) — translates the macro's declared `#{...}` into the allow-set, swaps it in around `eval_program`, restores the prior value after (composes for nested macro expansion). Replaced the no-op `check_compile_effects`.
- **Sandbox-escape closed** — `Async.spawn` is hard-denied inside the sandbox regardless of declared effects, because a freshly spawned OS thread would not inherit the thread-local.

Net effect: a dependency macro performing an undeclared effect now fails the build with a loud, source-pointing error. Declaring `#{IO Net}` becomes an explicit, reviewable capability declaration instead of silent code execution.

## Reviewer notes

- Runtime behavior is unchanged — the sandbox is `None` outside procedural macro expansion. A regression test (`runtime_effects_not_sandboxed`) guards this.
- Scope was deliberately kept to the enforcement layer. Tying the `#{...}` declaration itself to per-dependency `:grant` in the manifest (so the root project must *authorize* a dep's compile effects, not just the dep declaring them) is a natural follow-up that needs macro-provenance tracking through the module loader — out of scope here.
- Unrelated pre-existing whitespace changes in `eir/vm.rs` were left out of this PR.

## Test plan

- [x] `cargo test --workspace` — 466 tests, 0 failures
- [x] 5 new tests: undeclared effect denied, declared effect allowed, category isolation (`#{Print}` does not grant `Env`), `Async.spawn` always denied, runtime-not-sandboxed regression guard
- [x] `loon-cli` builds (with `pkg-fetch` feature)
- [x] No new clippy warnings in modified code

🤖 Generated with [Claude Code](https://claude.com/claude-code)