### PR TITLE
feat(fmt): comment-preserving formatter

### DIFF
--- a/crates/loon-cli/src/main.rs
+++ b/crates/loon-cli/src/main.rs
@@ -700,8 +700,8 @@ fn fmt_files(files: &[PathBuf], check: bool) {
             }
         };
 
-        let exprs = match loon_lang::parser::parse(&source) {
-            Ok(exprs) => exprs,
+        let (exprs, comments) = match loon_lang::parser::parse_with_comments(&source) {
+            Ok(out) => out,
             Err(e) => {
                 eprintln!(
                     "{} parsing {}: {}",
@@ -714,7 +714,7 @@ fn fmt_files(files: &[PathBuf], check: bool) {
             }
         };
 
-        let formatted = loon_lang::fmt::format_program(&exprs);
+        let formatted = loon_lang::fmt::format_program_with_comments(&exprs, &comments, &source);
 
         if formatted != source {
             changed_count += 1;

--- a/crates/loon-lang/src/fmt/mod.rs
+++ b/crates/loon-lang/src/fmt/mod.rs
@@ -1,10 +1,11 @@
 //! Wadler-Lindig style pretty printer for Loon source code.
 //!
 //! Known limitations:
-//! - Comments are lost (the lexer strips them at tokens.rs:28)
 //! - Numeric suffixes are lost (the parser converts e.g. `42i32` to `i64(42)`)
 
-use crate::ast::{Expr, ExprKind};
+use crate::ast::{Expr, ExprKind, NodeId};
+use crate::syntax::Comment;
+use std::collections::{HashMap, HashSet};
 
 // ---------------------------------------------------------------------------
 // Document algebra
@@ -160,7 +161,11 @@ fn fits(mut remaining: i32, cmds: &[DocCmd]) -> bool {
                 }
                 Mode::Break => return true, // line break always fits
             },
-            Doc::HardLine => return true,
+            // A hard break inside a group means the group cannot fit flat — it
+            // must render in Break mode so the surrounding soft `line()`s also
+            // break (otherwise they'd render as spaces and we'd get garbled
+            // output like a comment swallowing the line).
+            Doc::HardLine => return false,
             Doc::Indent(n, inner) => {
                 stack.push((ind + n, mode, inner));
             }
@@ -175,6 +180,222 @@ fn fits(mut remaining: i32, cmds: &[DocCmd]) -> bool {
     }
 
     false
+}
+
+// ---------------------------------------------------------------------------
+// Comment attachment
+// ---------------------------------------------------------------------------
+
+/// Comments attached to a particular AST node, by position relative to it.
+#[derive(Default, Debug)]
+struct NodeComments {
+    /// Own-line comment(s) that should print before the node.
+    leading: Vec<Comment>,
+    /// Same-line comment(s) that should print after the node on its closing line.
+    trailing: Vec<Comment>,
+    /// Comments inside this list/collection that come after the last child but
+    /// before the closing bracket — print on their own line(s) indented.
+    dangling: Vec<Comment>,
+}
+
+/// All comment / blank-line attachments for a program, keyed by `NodeId`.
+#[derive(Default, Debug)]
+struct Attachments {
+    by_node: HashMap<NodeId, NodeComments>,
+    /// Comments at the top of the file before any expression.
+    program_leading: Vec<Comment>,
+    /// Comments at the bottom of the file after the last expression.
+    program_trailing: Vec<Comment>,
+    /// Nodes whose preceding gap (within their sequence) contained a blank line
+    /// in the original source.
+    blank_before: HashSet<NodeId>,
+}
+
+/// Context threaded through doc builders so they can consult attachments.
+struct Ctx<'a> {
+    att: &'a Attachments,
+    /// Reserved for future use (currently only `att` is read inside builders).
+    #[allow(dead_code)]
+    src: &'a str,
+}
+
+const EMPTY_NC: &NodeComments = &NodeComments {
+    leading: Vec::new(),
+    trailing: Vec::new(),
+    dangling: Vec::new(),
+};
+
+impl<'a> Ctx<'a> {
+    fn nc(&self, id: NodeId) -> &NodeComments {
+        self.att.by_node.get(&id).unwrap_or(EMPTY_NC)
+    }
+}
+
+fn build_attachments(exprs: &[Expr], comments: &[Comment], source: &str) -> Attachments {
+    let mut att = Attachments::default();
+    if comments.is_empty() && exprs.is_empty() {
+        return att;
+    }
+    let mut sorted: Vec<Comment> = comments.to_vec();
+    sorted.sort_by_key(|c| c.span.start);
+    let mut idx = 0usize;
+    attach_seq(
+        exprs,
+        source,
+        None,
+        0,
+        source.len(),
+        &sorted,
+        &mut idx,
+        &mut att,
+        true,
+    );
+    att
+}
+
+#[allow(clippy::too_many_arguments)]
+fn attach_seq(
+    children: &[Expr],
+    source: &str,
+    enclosing_id: Option<NodeId>,
+    seq_start: usize,
+    seq_end: usize,
+    comments: &[Comment],
+    idx: &mut usize,
+    att: &mut Attachments,
+    is_program: bool,
+) {
+    let mut prev_end: usize = seq_start;
+    let mut prev_id: Option<NodeId> = None;
+
+    for child in children {
+        // Drain comments that fall before this child.
+        while *idx < comments.len() && comments[*idx].span.start < child.span.start {
+            let c = comments[*idx].clone();
+            *idx += 1;
+            // Same-line trailing of previous sibling?
+            if let Some(pid) = prev_id {
+                let between = source.get(prev_end..c.span.start).unwrap_or("");
+                if !between.contains('\n') {
+                    att.by_node.entry(pid).or_default().trailing.push(c.clone());
+                    prev_end = c.span.end;
+                    continue;
+                }
+                // Non-trailing comment: detect a blank line in the gap before
+                // it. The blank "belongs to" the upcoming child since this
+                // comment will print as leading of that child.
+                if count_newlines(between) >= 2 {
+                    att.blank_before.insert(child.id);
+                }
+            }
+            // Otherwise leading of the upcoming child — or program_leading at the
+            // very top of file.
+            if prev_id.is_none() && is_program {
+                att.program_leading.push(c.clone());
+            } else {
+                att.by_node
+                    .entry(child.id)
+                    .or_default()
+                    .leading
+                    .push(c.clone());
+            }
+            prev_end = c.span.end;
+        }
+
+        // Blank-line detection in the gap before this child (between siblings only;
+        // the program_leading → first expr boundary uses its own rule).
+        let gap = source.get(prev_end..child.span.start).unwrap_or("");
+        if (prev_id.is_some() || (is_program && !att.program_leading.is_empty()))
+            && count_newlines(gap) >= 2
+        {
+            att.blank_before.insert(child.id);
+        }
+
+        // Recurse into the child to handle its own nested sequences.
+        attach_into(child, source, comments, idx, att);
+
+        prev_end = child.span.end;
+        prev_id = Some(child.id);
+    }
+
+    // Comments after the last child but before this sequence's end.
+    while *idx < comments.len() && comments[*idx].span.start < seq_end {
+        let c = comments[*idx].clone();
+        *idx += 1;
+        // Same-line trailing of the last child?
+        if let Some(pid) = prev_id {
+            let between = source.get(prev_end..c.span.start).unwrap_or("");
+            if !between.contains('\n') {
+                att.by_node.entry(pid).or_default().trailing.push(c.clone());
+                prev_end = c.span.end;
+                continue;
+            }
+        }
+        // Dangling on the enclosing list, or program_trailing at the top level.
+        if let Some(eid) = enclosing_id {
+            att.by_node.entry(eid).or_default().dangling.push(c.clone());
+        } else {
+            att.program_trailing.push(c.clone());
+        }
+        prev_end = c.span.end;
+    }
+}
+
+fn attach_into(
+    expr: &Expr,
+    source: &str,
+    comments: &[Comment],
+    idx: &mut usize,
+    att: &mut Attachments,
+) {
+    match &expr.kind {
+        ExprKind::List(items)
+        | ExprKind::Vec(items)
+        | ExprKind::Set(items)
+        | ExprKind::Tuple(items) => {
+            attach_seq(
+                items,
+                source,
+                Some(expr.id),
+                expr.span.start,
+                expr.span.end,
+                comments,
+                idx,
+                att,
+                false,
+            );
+        }
+        ExprKind::Map(pairs) => {
+            // Flatten key/value into a synthetic sequence so comments between
+            // pairs (or between a key and its value) land on the right node.
+            let flat: Vec<Expr> = pairs
+                .iter()
+                .flat_map(|(k, v)| [k.clone(), v.clone()])
+                .collect();
+            attach_seq(
+                &flat,
+                source,
+                Some(expr.id),
+                expr.span.start,
+                expr.span.end,
+                comments,
+                idx,
+                att,
+                false,
+            );
+        }
+        ExprKind::DotAccess(inner, _)
+        | ExprKind::Quote(inner)
+        | ExprKind::Unquote(inner)
+        | ExprKind::UnquoteSplice(inner) => {
+            attach_into(inner, source, comments, idx, att);
+        }
+        _ => {} // atoms have no children
+    }
+}
+
+fn count_newlines(s: &str) -> usize {
+    s.bytes().filter(|&b| b == b'\n').count()
 }
 
 // ---------------------------------------------------------------------------
@@ -198,7 +419,63 @@ fn escape_string(s: &str) -> String {
     out
 }
 
-fn expr_to_doc(expr: &Expr) -> Doc {
+/// Produce the doc for an expression's core (no leading or trailing comments).
+/// Comments are emitted by the enclosing sequence printer (`fmt_children`) or
+/// special-form printers, which know where in the doc tree to place hard breaks
+/// so the surrounding indent context applies correctly.
+fn expr_to_doc(expr: &Expr, ctx: &Ctx) -> Doc {
+    expr_kind_to_doc(expr, ctx)
+}
+
+/// Emit the trailing comments for a node as ` ; text` repeats — without any
+/// hard break (callers decide where the break goes so it can fire inside the
+/// right indent context).
+fn trailing_doc(expr: &Expr, ctx: &Ctx) -> Doc {
+    let nc = ctx.nc(expr.id);
+    if nc.trailing.is_empty() {
+        return nil();
+    }
+    let mut parts = Vec::new();
+    for c in &nc.trailing {
+        parts.push(text(" "));
+        parts.push(text(c.text.clone()));
+    }
+    concat_all(parts)
+}
+
+/// Doc to place between a special form's header (its last header item) and its
+/// indented body. If the last header item has a trailing comment, emit it here
+/// followed by a hard break so the body starts on a new indented line; this
+/// lives inside the indent block so the hard break uses the body's indent.
+/// Otherwise emit a soft `line()` so the form can fit flat when small.
+fn body_break(last_header: &Expr, ctx: &Ctx) -> Doc {
+    let nc = ctx.nc(last_header.id);
+    if nc.trailing.is_empty() {
+        return line();
+    }
+    let mut parts = Vec::new();
+    for c in &nc.trailing {
+        parts.push(text(" "));
+        parts.push(text(c.text.clone()));
+    }
+    parts.push(hard_line());
+    concat_all(parts)
+}
+
+/// Doc to place between the body of a special form and its closing bracket.
+/// If the last body item has a trailing comment, emit a hard break so the
+/// closing bracket lands on its own line (a comment runs to EOL, so the bracket
+/// cannot share a line with it). This lives outside the indent block so the
+/// closing bracket emits at column 0.
+fn close_after(last_body: &Expr, ctx: &Ctx) -> Doc {
+    if ctx.nc(last_body.id).trailing.is_empty() {
+        nil()
+    } else {
+        hard_line()
+    }
+}
+
+fn expr_kind_to_doc(expr: &Expr, ctx: &Ctx) -> Doc {
     match &expr.kind {
         ExprKind::Int(n) => text(n.to_string()),
         ExprKind::Float(n) => text(format!("{n}")),
@@ -207,22 +484,87 @@ fn expr_to_doc(expr: &Expr) -> Doc {
         ExprKind::Keyword(k) => text(format!(":{k}")),
         ExprKind::Symbol(s) => text(s.clone()),
 
-        ExprKind::List(items) => list_to_doc(items),
-        ExprKind::Vec(items) => collection_to_doc("#[", "]", items),
-        ExprKind::Set(items) => collection_to_doc("#{", "}", items),
-        ExprKind::Map(pairs) => map_to_doc(pairs),
-        ExprKind::Tuple(items) => tuple_to_doc(items),
-        ExprKind::DotAccess(inner, field) => {
-            concat(concat(expr_to_doc(inner), text(".")), text(field.clone()))
-        }
-        ExprKind::Quote(inner) => concat(text("`"), expr_to_doc(inner)),
-        ExprKind::Unquote(inner) => concat(text("~"), expr_to_doc(inner)),
-        ExprKind::UnquoteSplice(inner) => concat(text("~@"), expr_to_doc(inner)),
+        ExprKind::List(items) => list_to_doc(expr.id, items, ctx),
+        ExprKind::Vec(items) => collection_to_doc(expr.id, "#[", "]", items, ctx),
+        ExprKind::Set(items) => collection_to_doc(expr.id, "#{", "}", items, ctx),
+        ExprKind::Map(pairs) => map_to_doc(expr.id, pairs, ctx),
+        ExprKind::Tuple(items) => tuple_to_doc(expr.id, items, ctx),
+        ExprKind::DotAccess(inner, field) => concat(
+            concat(expr_to_doc(inner, ctx), text(".")),
+            text(field.clone()),
+        ),
+        ExprKind::Quote(inner) => concat(text("`"), expr_to_doc(inner, ctx)),
+        ExprKind::Unquote(inner) => concat(text("~"), expr_to_doc(inner, ctx)),
+        ExprKind::UnquoteSplice(inner) => concat(text("~@"), expr_to_doc(inner, ctx)),
     }
 }
 
+/// Emit a sequence of sibling expressions with `sep` as the default separator.
+/// Inserts leading comments, blank lines, and forces hard breaks around any
+/// child that has leading/trailing comments or a blank line before it. Handles
+/// the parent node's `dangling` comments (printed on their own lines before the
+/// closing bracket) when `parent` is `Some`.
+fn fmt_children(parent: Option<NodeId>, items: &[Expr], sep: Doc, ctx: &Ctx) -> Doc {
+    let dangling = parent
+        .map(|id| ctx.nc(id).dangling.as_slice())
+        .unwrap_or(&[]);
+
+    if items.is_empty() {
+        if dangling.is_empty() {
+            return nil();
+        }
+        let mut parts: Vec<Doc> = Vec::new();
+        for c in dangling {
+            parts.push(hard_line());
+            parts.push(text(c.text.clone()));
+        }
+        return concat_all(parts);
+    }
+
+    let mut parts: Vec<Doc> = Vec::new();
+    for (i, item) in items.iter().enumerate() {
+        let nc = ctx.nc(item.id);
+
+        if i > 0 {
+            let prev_nc = ctx.nc(items[i - 1].id);
+            let prev_trailing = !prev_nc.trailing.is_empty();
+            let this_leading = !nc.leading.is_empty();
+            let blank = ctx.att.blank_before.contains(&item.id);
+
+            if prev_trailing || this_leading || blank {
+                parts.push(hard_line());
+                if blank {
+                    parts.push(hard_line());
+                }
+            } else {
+                parts.push(sep.clone());
+            }
+        }
+
+        // Leading comments before this item — each on its own line.
+        for c in &nc.leading {
+            parts.push(text(c.text.clone()));
+            parts.push(hard_line());
+        }
+
+        parts.push(expr_to_doc(item, ctx));
+        // Same-line trailing comments. No hard break here — the next
+        // sibling's `prev_trailing` check handles that, or `close_after`
+        // does at the parent boundary.
+        parts.push(trailing_doc(item, ctx));
+    }
+
+    // Dangling comments before the close.
+    for c in dangling {
+        parts.push(hard_line());
+        parts.push(text(c.text.clone()));
+    }
+
+    concat_all(parts)
+}
+
 /// Format a List (s-expression) `[head args...]` with form-specific rules.
-fn list_to_doc(items: &[Expr]) -> Doc {
+fn list_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.is_empty() {
         return text("[]");
     }
@@ -237,291 +579,467 @@ fn list_to_doc(items: &[Expr]) -> Doc {
         Some("fn") => {
             // Named fn: [fn name [params] body...] vs anonymous: [fn [params] body...]
             if items.len() >= 2 && matches!(&items[1].kind, ExprKind::Symbol(_)) {
-                defn_to_doc(items)
+                defn_to_doc(id, items, ctx)
             } else {
-                fn_to_doc(items)
+                fn_to_doc(id, items, ctx)
             }
         }
-        Some("let") => let_to_doc(items),
-        Some("if") => if_to_doc(items),
-        Some("match") => match_to_doc(items),
-        Some("pipe") => pipe_to_doc(items),
-        Some("type") => type_to_doc(items),
-        Some("effect") => type_to_doc(items), // same layout as type
-        _ => generic_list_to_doc(items),
+        Some("let") => let_to_doc(id, items, ctx),
+        Some("if") => if_to_doc(id, items, ctx),
+        Some("match") => match_to_doc(id, items, ctx),
+        Some("pipe") => pipe_to_doc(id, items, ctx),
+        Some("type") => type_to_doc(id, items, ctx),
+        Some("effect") => type_to_doc(id, items, ctx), // same layout as type
+        _ => generic_list_to_doc(id, items, ctx),
     }
 }
 
 /// `[fn name [params...] body...]`
 /// Name+params on first line, body indented 2. Blank line between top-level defns
 /// is handled in `format_program`.
-fn defn_to_doc(items: &[Expr]) -> Doc {
+fn defn_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     // items[0] = defn, items[1] = name, items[2] = params, items[3..] = body
     if items.len() < 3 {
-        return generic_list_to_doc(items);
+        return generic_list_to_doc(id, items, ctx);
     }
 
-    let keyword = expr_to_doc(&items[0]);
-    let name = expr_to_doc(&items[1]);
-    let params = expr_to_doc(&items[2]);
+    let keyword = expr_to_doc(&items[0], ctx);
+    let name = expr_to_doc(&items[1], ctx);
+    let params = expr_to_doc(&items[2], ctx);
 
     let header = concat_all(vec![text("["), keyword, text(" "), name, text(" "), params]);
 
     if items.len() == 3 {
-        return concat(header, text("]"));
+        return concat(concat(header, trailing_doc(&items[2], ctx)), text("]"));
     }
 
-    let body_docs: Vec<Doc> = items[3..].iter().map(expr_to_doc).collect();
-    let body = intersperse(body_docs, line());
+    let body = fmt_children(Some(id), &items[3..], line(), ctx);
+    let last_body = items.last().unwrap();
 
     group(concat_all(vec![
         header,
-        indent(INDENT_SIZE, concat(line(), body)),
+        indent(INDENT_SIZE, concat(body_break(&items[2], ctx), body)),
+        close_after(last_body, ctx),
         text("]"),
     ]))
 }
 
 /// `[fn [params...] body...]`
-fn fn_to_doc(items: &[Expr]) -> Doc {
+fn fn_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.len() < 2 {
-        return generic_list_to_doc(items);
+        return generic_list_to_doc(id, items, ctx);
     }
 
-    let keyword = expr_to_doc(&items[0]);
-    let params = expr_to_doc(&items[1]);
+    let keyword = expr_to_doc(&items[0], ctx);
+    let params = expr_to_doc(&items[1], ctx);
 
     let header = concat_all(vec![text("["), keyword, text(" "), params]);
 
     if items.len() == 2 {
-        return concat(header, text("]"));
+        return concat(concat(header, trailing_doc(&items[1], ctx)), text("]"));
     }
 
-    let body_docs: Vec<Doc> = items[2..].iter().map(expr_to_doc).collect();
-    let body = intersperse(body_docs, line());
+    let body = fmt_children(Some(id), &items[2..], line(), ctx);
+    let last_body = items.last().unwrap();
 
     group(concat_all(vec![
         header,
-        indent(INDENT_SIZE, concat(line(), body)),
+        indent(INDENT_SIZE, concat(body_break(&items[1], ctx), body)),
+        close_after(last_body, ctx),
         text("]"),
     ]))
 }
 
 /// `[let name value]` — single line if fits, break after name otherwise.
-fn let_to_doc(items: &[Expr]) -> Doc {
+fn let_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.len() < 3 {
-        return generic_list_to_doc(items);
+        return generic_list_to_doc(id, items, ctx);
     }
 
     // Could be [let name val] or [let mut name val]
-    let docs: Vec<Doc> = items.iter().map(expr_to_doc).collect();
+    let head = expr_to_doc(&items[0], ctx);
+    let body = fmt_children(Some(id), &items[1..], line(), ctx);
+    let last_body = items.last().unwrap();
 
     group(concat_all(vec![
         text("["),
-        docs[0].clone(),
+        head,
+        trailing_doc(&items[0], ctx),
         text(" "),
-        intersperse(docs[1..].to_vec(), line()),
+        body,
+        close_after(last_body, ctx),
         text("]"),
     ]))
 }
 
 /// `[if cond then else]` — inline if fits; cond on same line, then/else indented.
-fn if_to_doc(items: &[Expr]) -> Doc {
+fn if_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.len() < 3 {
-        return generic_list_to_doc(items);
+        return generic_list_to_doc(id, items, ctx);
     }
 
-    let keyword = expr_to_doc(&items[0]);
-    let cond = expr_to_doc(&items[1]);
+    let keyword = expr_to_doc(&items[0], ctx);
+    let cond = expr_to_doc(&items[1], ctx);
 
-    let branches: Vec<Doc> = items[2..].iter().map(expr_to_doc).collect();
-    let body = intersperse(branches, line());
+    let body = fmt_children(Some(id), &items[2..], line(), ctx);
+    let last_body = items.last().unwrap();
 
     group(concat_all(vec![
         text("["),
         keyword,
         text(" "),
         cond,
-        indent(INDENT_SIZE, concat(line(), body)),
+        indent(INDENT_SIZE, concat(body_break(&items[1], ctx), body)),
+        close_after(last_body, ctx),
         text("]"),
     ]))
 }
 
-/// `[match expr arms...]` — expr on first line, each arm on own indented line.
-fn match_to_doc(items: &[Expr]) -> Doc {
+/// `[match scrutinee pat body pat body ...]` — each (pat, body) on its own line,
+/// never collapses onto a single line.
+fn match_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.len() < 2 {
-        return generic_list_to_doc(items);
+        return generic_list_to_doc(id, items, ctx);
     }
 
-    let keyword = expr_to_doc(&items[0]);
-    let scrutinee = expr_to_doc(&items[1]);
+    let keyword = expr_to_doc(&items[0], ctx);
+    let scrutinee = expr_to_doc(&items[1], ctx);
 
     let header = concat_all(vec![text("["), keyword, text(" "), scrutinee]);
 
     if items.len() == 2 {
-        return concat(header, text("]"));
+        return concat(concat(header, trailing_doc(&items[1], ctx)), text("]"));
     }
 
-    let arm_docs: Vec<Doc> = items[2..].iter().map(expr_to_doc).collect();
-    let arms = intersperse(arm_docs, line());
+    // Build a doc per (pattern, body) pair so arms never collapse onto one line.
+    // Comments attached to the pattern node naturally precede the pair; comments
+    // on the body land trailing after it.
+    let arms = &items[2..];
+    let mut pair_docs: Vec<Doc> = Vec::new();
+    let mut i = 0;
+    while i < arms.len() {
+        let pat = &arms[i];
+
+        let nc = ctx.nc(pat.id);
+        let blank = ctx.att.blank_before.contains(&pat.id);
+        let mut pair: Vec<Doc> = Vec::new();
+        if !pair_docs.is_empty() && blank {
+            pair.push(hard_line());
+        }
+        for c in &nc.leading {
+            pair.push(text(c.text.clone()));
+            pair.push(hard_line());
+        }
+
+        if i + 1 < arms.len() {
+            // pattern body
+            pair.push(expr_to_doc(pat, ctx));
+            pair.push(trailing_doc(pat, ctx));
+            pair.push(text(" "));
+            pair.push(expr_to_doc(&arms[i + 1], ctx));
+            pair.push(trailing_doc(&arms[i + 1], ctx));
+            i += 2;
+        } else {
+            // odd trailing pattern with no body
+            pair.push(expr_to_doc(pat, ctx));
+            pair.push(trailing_doc(pat, ctx));
+            i += 1;
+        }
+        pair_docs.push(concat_all(pair));
+    }
+
+    let arms_doc = intersperse(pair_docs, hard_line());
+
+    // Dangling comments inside the match list (before `]`).
+    let dangling = ctx.nc(id).dangling.as_slice();
+    let mut tail: Vec<Doc> = Vec::new();
+    for c in dangling {
+        tail.push(hard_line());
+        tail.push(text(c.text.clone()));
+    }
+
+    let last_arm = items.last().unwrap();
+    let between = if ctx.nc(items[1].id).trailing.is_empty() {
+        hard_line()
+    } else {
+        body_break(&items[1], ctx)
+    };
 
     concat_all(vec![
         header,
-        indent(INDENT_SIZE, concat(hard_line(), arms)),
+        indent(
+            INDENT_SIZE,
+            concat(between, concat_all(vec![arms_doc, concat_all(tail)])),
+        ),
+        close_after(last_arm, ctx),
         text("]"),
     ])
 }
 
 /// `[pipe expr steps...]` — first expr on same line, each step indented on own line.
-fn pipe_to_doc(items: &[Expr]) -> Doc {
+fn pipe_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.len() < 2 {
-        return generic_list_to_doc(items);
+        return generic_list_to_doc(id, items, ctx);
     }
 
-    let keyword = expr_to_doc(&items[0]);
-    let first = expr_to_doc(&items[1]);
+    let keyword = expr_to_doc(&items[0], ctx);
+    let first = expr_to_doc(&items[1], ctx);
 
     let header = concat_all(vec![text("["), keyword, text(" "), first]);
 
     if items.len() == 2 {
-        return concat(header, text("]"));
+        return concat(concat(header, trailing_doc(&items[1], ctx)), text("]"));
     }
 
-    let step_docs: Vec<Doc> = items[2..].iter().map(expr_to_doc).collect();
-    let steps = intersperse(step_docs, line());
+    let steps = fmt_children(Some(id), &items[2..], line(), ctx);
+    let last_body = items.last().unwrap();
 
     group(concat_all(vec![
         header,
-        indent(INDENT_SIZE, concat(line(), steps)),
+        indent(INDENT_SIZE, concat(body_break(&items[1], ctx), steps)),
+        close_after(last_body, ctx),
         text("]"),
     ]))
 }
 
 /// `[type Name constructors...]` or `[effect Name ops...]`
 /// Name on first line, constructors/ops indented.
-fn type_to_doc(items: &[Expr]) -> Doc {
+fn type_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.len() < 2 {
-        return generic_list_to_doc(items);
+        return generic_list_to_doc(id, items, ctx);
     }
 
-    let keyword = expr_to_doc(&items[0]);
-    let name = expr_to_doc(&items[1]);
+    let keyword = expr_to_doc(&items[0], ctx);
+    let name = expr_to_doc(&items[1], ctx);
 
     let header = concat_all(vec![text("["), keyword, text(" "), name]);
 
     if items.len() == 2 {
-        return concat(header, text("]"));
+        return concat(concat(header, trailing_doc(&items[1], ctx)), text("]"));
     }
 
-    let body_docs: Vec<Doc> = items[2..].iter().map(expr_to_doc).collect();
-    let body = intersperse(body_docs, line());
+    let body = fmt_children(Some(id), &items[2..], line(), ctx);
+    let last_body = items.last().unwrap();
+    // `type` / `effect` always render one constructor per line (hard_line); but
+    // if items[1] has a trailing comment, emit it before the hard break.
+    let between = if ctx.nc(items[1].id).trailing.is_empty() {
+        hard_line()
+    } else {
+        body_break(&items[1], ctx)
+    };
 
     concat_all(vec![
         header,
-        indent(INDENT_SIZE, concat(hard_line(), body)),
+        indent(INDENT_SIZE, concat(between, body)),
+        close_after(last_body, ctx),
         text("]"),
     ])
 }
 
 /// Generic list: inline if fits, head on first line + args indented.
-fn generic_list_to_doc(items: &[Expr]) -> Doc {
+fn generic_list_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.is_empty() {
         return text("[]");
     }
 
     if items.len() == 1 {
-        return concat_all(vec![text("["), expr_to_doc(&items[0]), text("]")]);
+        return concat_all(vec![
+            text("["),
+            expr_to_doc(&items[0], ctx),
+            trailing_doc(&items[0], ctx),
+            close_after(&items[0], ctx),
+            text("]"),
+        ]);
     }
 
-    let head = expr_to_doc(&items[0]);
-    let arg_docs: Vec<Doc> = items[1..].iter().map(expr_to_doc).collect();
-    let args = intersperse(arg_docs, line());
+    let head = expr_to_doc(&items[0], ctx);
+    let args = fmt_children(Some(id), &items[1..], line(), ctx);
+    let last_body = items.last().unwrap();
 
     group(concat_all(vec![
         text("["),
         head,
-        indent(INDENT_SIZE, concat(line(), args)),
+        indent(INDENT_SIZE, concat(body_break(&items[0], ctx), args)),
+        close_after(last_body, ctx),
         text("]"),
     ]))
 }
 
 /// Vec `#[a b c]` and Set `#{a b c}`: inline if fits, one per line otherwise.
-fn collection_to_doc(open: &str, close: &str, items: &[Expr]) -> Doc {
+fn collection_to_doc(id: NodeId, open: &str, close: &str, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.is_empty() {
         return text(format!("{open}{close}"));
     }
 
-    let docs: Vec<Doc> = items.iter().map(expr_to_doc).collect();
-    let body = intersperse(docs, line());
+    let body = fmt_children(Some(id), items, line(), ctx);
+    let last = items.last().unwrap();
 
     group(concat_all(vec![
         text(open),
         indent(INDENT_SIZE, body),
+        close_after(last, ctx),
         text(close),
     ]))
 }
 
 /// Map `{:key val ...}`: key-value pairs aligned, one per line if > 80 chars.
-fn map_to_doc(pairs: &[(Expr, Expr)]) -> Doc {
+fn map_to_doc(id: NodeId, pairs: &[(Expr, Expr)], ctx: &Ctx) -> Doc {
     if pairs.is_empty() {
         return text("{}");
     }
 
-    let pair_docs: Vec<Doc> = pairs
-        .iter()
-        .map(|(k, v)| concat_all(vec![expr_to_doc(k), text(" "), expr_to_doc(v)]))
-        .collect();
-    let body = intersperse(pair_docs, line());
+    // For comment purposes the parser tree treats k and v as separate nodes; but
+    // here we group each pair tightly (no break between k and v). Comments
+    // attached to the key are leading on the pair; comments attached to the
+    // value are trailing on the pair.
+    let mut pair_docs: Vec<Doc> = Vec::new();
+    let mut leading_per_pair: Vec<Vec<Comment>> = Vec::new();
+    let mut blank_per_pair: Vec<bool> = Vec::new();
+    let mut trailing_after_pair: Vec<Vec<Comment>> = Vec::new();
+
+    for (k, v) in pairs.iter() {
+        let knc = ctx.nc(k.id);
+        let vnc = ctx.nc(v.id);
+        leading_per_pair.push(knc.leading.clone());
+        blank_per_pair.push(ctx.att.blank_before.contains(&k.id));
+        // Build the pair body: k + space + v (without leading on k, since we lift
+        // it to before the pair; trailing on v stays attached to v).
+        let k_core = expr_kind_to_doc(k, ctx);
+        let mut k_trailing: Vec<Doc> = Vec::new();
+        for c in &knc.trailing {
+            k_trailing.push(text(" "));
+            k_trailing.push(text(c.text.clone()));
+        }
+        let v_doc = expr_to_doc(v, ctx);
+        let pair = concat_all(vec![k_core, concat_all(k_trailing), text(" "), v_doc]);
+        pair_docs.push(pair);
+        trailing_after_pair.push(vnc.trailing.clone());
+    }
+
+    // Assemble with separators.
+    let mut parts: Vec<Doc> = Vec::new();
+    for (i, pd) in pair_docs.into_iter().enumerate() {
+        if i > 0 {
+            let prev_trailing = !trailing_after_pair[i - 1].is_empty();
+            let this_leading = !leading_per_pair[i].is_empty();
+            let blank = blank_per_pair[i];
+            if prev_trailing || this_leading || blank {
+                parts.push(hard_line());
+                if blank {
+                    parts.push(hard_line());
+                }
+            } else {
+                parts.push(line());
+            }
+        }
+        for c in &leading_per_pair[i] {
+            parts.push(text(c.text.clone()));
+            parts.push(hard_line());
+        }
+        parts.push(pd);
+    }
+
+    // Dangling on the map node itself.
+    for c in &ctx.nc(id).dangling {
+        parts.push(hard_line());
+        parts.push(text(c.text.clone()));
+    }
 
     group(concat_all(vec![
         text("{"),
-        indent(INDENT_SIZE, body),
+        indent(INDENT_SIZE, concat_all(parts)),
         text("}"),
     ]))
 }
 
 /// Tuple `(a, b)`.
-fn tuple_to_doc(items: &[Expr]) -> Doc {
+fn tuple_to_doc(id: NodeId, items: &[Expr], ctx: &Ctx) -> Doc {
     if items.is_empty() {
         return text("()");
     }
 
-    let docs: Vec<Doc> = items.iter().map(expr_to_doc).collect();
-    let body = intersperse(docs, line());
+    let body = fmt_children(Some(id), items, line(), ctx);
+    let last = items.last().unwrap();
 
-    group(concat_all(vec![text("("), body, text(")")]))
+    group(concat_all(vec![
+        text("("),
+        body,
+        close_after(last, ctx),
+        text(")"),
+    ]))
 }
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Format a parsed Loon program back to source code.
-///
-/// Inserts blank lines between top-level `defn` forms.
+/// Format a parsed Loon program back to source code (comment-less variant kept
+/// for back-compat). Inserts blank lines between top-level `defn` forms.
 pub fn format_program(exprs: &[Expr]) -> String {
-    if exprs.is_empty() {
+    format_program_with_comments(exprs, &[], "")
+}
+
+/// Format a parsed Loon program back to source code, preserving comments and
+/// intentional blank lines from `source`. `comments` are the comments captured
+/// by `parser::parse_with_comments`; `source` is the original buffer (used for
+/// position-based attachment decisions).
+pub fn format_program_with_comments(exprs: &[Expr], comments: &[Comment], source: &str) -> String {
+    if exprs.is_empty() && comments.is_empty() {
         return String::new();
     }
 
+    let att = build_attachments(exprs, comments, source);
+    let ctx = Ctx {
+        att: &att,
+        src: source,
+    };
+
     let mut parts: Vec<String> = Vec::new();
 
-    for (i, expr) in exprs.iter().enumerate() {
-        let doc = expr_to_doc(expr);
-        let formatted = render(&doc, DEFAULT_WIDTH);
-        parts.push(formatted);
+    // Program-leading comments at the very top of the file.
+    for c in &ctx.att.program_leading {
+        parts.push(c.text.clone());
+    }
 
-        // Insert blank line between top-level defns
+    for (i, expr) in exprs.iter().enumerate() {
+        let nc = ctx.nc(expr.id);
+
+        // Leading comments on this top-level expr (own-line).
+        for c in &nc.leading {
+            parts.push(c.text.clone());
+        }
+
+        // Render the expr itself, with its own trailing comments appended.
+        let doc = expr_kind_to_doc(expr, &ctx);
+        let mut rendered = render(&doc, DEFAULT_WIDTH);
+        for c in &nc.trailing {
+            rendered.push(' ');
+            rendered.push_str(&c.text);
+        }
+        parts.push(rendered);
+
         if i + 1 < exprs.len() {
-            let is_defn = is_top_level_defn(expr);
-            let next_is_defn = is_top_level_defn(&exprs[i + 1]);
-            if is_defn || next_is_defn {
+            let next = &exprs[i + 1];
+            let blank = ctx.att.blank_before.contains(&next.id);
+            let is_defn = is_top_level_defn(expr) || is_top_level_defn(next);
+
+            // Blank line between top-level defns (existing behavior) or when
+            // the source explicitly had one. Trailing/leading comments alone do
+            // NOT force a blank line at the top level — the `\n` from joining
+            // is sufficient, and inserting a blank line would distort the
+            // user's original spacing on every save.
+            if blank || is_defn {
                 parts.push(String::new());
             }
         }
     }
 
+    // Program-trailing comments at the bottom.
+    for c in &ctx.att.program_trailing {
+        parts.push(c.text.clone());
+    }
+
     let mut result = parts.join("\n");
-    // Ensure trailing newline
     if !result.ends_with('\n') {
         result.push('\n');
     }
@@ -546,11 +1064,16 @@ fn is_top_level_defn(expr: &Expr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::parse;
+    use crate::parser::{parse, parse_with_comments};
 
     fn fmt(src: &str) -> String {
         let exprs = parse(src).expect("parse failed");
         format_program(&exprs)
+    }
+
+    fn fmt_with_comments(src: &str) -> String {
+        let (exprs, comments) = parse_with_comments(src).expect("parse failed");
+        format_program_with_comments(&exprs, &comments, src)
     }
 
     // -- Idempotency tests --------------------------------------------------
@@ -559,6 +1082,15 @@ mod tests {
         let first = fmt(src);
         let second = fmt(&first);
         assert_eq!(first, second, "formatting is not idempotent for: {src}");
+    }
+
+    fn assert_idempotent_with_comments(src: &str) {
+        let first = fmt_with_comments(src);
+        let second = fmt_with_comments(&first);
+        assert_eq!(
+            first, second,
+            "formatting (with comments) is not idempotent for: {src}\nfirst:\n{first}\nsecond:\n{second}"
+        );
     }
 
     #[test]
@@ -731,6 +1263,102 @@ mod tests {
     fn format_match_arms() {
         let result = fmt("[match x [Some v] v None 0]");
         assert!(result.contains("[match x"));
+    }
+
+    #[test]
+    fn match_arms_stay_on_own_lines() {
+        // Previously this collapsed to one line; now each (pat, body) pair is
+        // on its own indented line.
+        let src =
+            "[fn fib [n]\n  [match n\n    0 0\n    1 1\n    n [+ [fib [- n 1]] [fib [- n 2]]]]]";
+        let result = fmt(src);
+        // Each pair on its own line means the result has 3+ newlines inside
+        // the match body.
+        let match_part = result.split("[match").nth(1).unwrap_or("");
+        let body = match_part.split("]]").next().unwrap_or("");
+        let newlines = body.matches('\n').count();
+        assert!(
+            newlines >= 3,
+            "expected match arms on separate lines (>=3 newlines in body), got {newlines}:\n{result}"
+        );
+    }
+
+    // -- Comment preservation tests -----------------------------------------
+
+    #[test]
+    fn leading_comment_preserved() {
+        let src = "; header\n[let x 42]\n";
+        let out = fmt_with_comments(src);
+        assert!(out.contains("; header"), "got:\n{out}");
+        assert!(out.contains("[let x 42]"), "got:\n{out}");
+        assert_idempotent_with_comments(src);
+    }
+
+    #[test]
+    fn trailing_same_line_comment_preserved() {
+        let src = "[let x 42] ; the answer\n";
+        let out = fmt_with_comments(src);
+        assert!(out.contains("[let x 42]"), "got:\n{out}");
+        assert!(out.contains("; the answer"), "got:\n{out}");
+        assert_idempotent_with_comments(src);
+    }
+
+    #[test]
+    fn comment_only_file_round_trips() {
+        let src = "; just a comment\n";
+        let out = fmt_with_comments(src);
+        assert!(out.contains("; just a comment"), "got:\n{out}");
+        assert_idempotent_with_comments(src);
+    }
+
+    #[test]
+    fn consecutive_comments_preserved() {
+        let src = "; one\n; two\n; three\n[let x 1]\n";
+        let out = fmt_with_comments(src);
+        assert!(out.contains("; one"), "got:\n{out}");
+        assert!(out.contains("; two"), "got:\n{out}");
+        assert!(out.contains("; three"), "got:\n{out}");
+        assert_idempotent_with_comments(src);
+    }
+
+    #[test]
+    fn comment_inside_list_preserved() {
+        let src = "[fn foo []\n  ; body comment\n  [+ 1 2]]\n";
+        let out = fmt_with_comments(src);
+        assert!(out.contains("; body comment"), "got:\n{out}");
+        assert_idempotent_with_comments(src);
+    }
+
+    #[test]
+    fn eof_comment_preserved() {
+        let src = "[let x 1]\n; trailing\n";
+        let out = fmt_with_comments(src);
+        assert!(out.contains("; trailing"), "got:\n{out}");
+        assert_idempotent_with_comments(src);
+    }
+
+    #[test]
+    fn user_blank_line_preserved() {
+        let src = "[let x 1]\n\n[let y 2]\n";
+        let out = fmt_with_comments(src);
+        assert!(
+            out.contains("\n\n"),
+            "expected a blank line between forms, got:\n{out}"
+        );
+        assert_idempotent_with_comments(src);
+    }
+
+    #[test]
+    fn multiple_blank_lines_collapse_to_one() {
+        let src = "[let x 1]\n\n\n\n[let y 2]\n";
+        let out = fmt_with_comments(src);
+        // Idempotence is what matters — repeated blank lines must collapse to
+        // a stable single blank-line form.
+        let second = fmt_with_comments(&out);
+        assert_eq!(
+            out, second,
+            "expected stable collapse, got:\nfirst:\n{out}\nsecond:\n{second}"
+        );
     }
 
     // -- Doc algebra unit tests ---------------------------------------------

--- a/crates/loon-lang/src/parser/mod.rs
+++ b/crates/loon-lang/src/parser/mod.rs
@@ -1,5 +1,5 @@
 use crate::ast::{Expr, ExprKind};
-use crate::syntax::{Span, Token};
+use crate::syntax::{Comment, Span, Token};
 use logos::Logos;
 
 #[derive(Debug, Clone)]
@@ -41,6 +41,7 @@ fn extract_suffix(s: &str) -> String {
 
 struct Parser<'a> {
     tokens: Vec<(Token, Span)>,
+    comments: Vec<Comment>,
     pos: usize,
     source: &'a str,
 }
@@ -48,11 +49,13 @@ struct Parser<'a> {
 impl<'a> Parser<'a> {
     fn new(source: &'a str) -> Result<Self, ParseError> {
         let mut tokens = Vec::new();
+        let mut comments = Vec::new();
         let mut lexer = Token::lexer(source);
         while let Some(tok) = lexer.next() {
             let span = lexer.span();
             let span = Span::new(span.start, span.end);
             match tok {
+                Ok(Token::Comment(text)) => comments.push(Comment { span, text }),
                 Ok(t) => tokens.push((t, span)),
                 Err(()) => {
                     return Err(ParseError {
@@ -67,6 +70,7 @@ impl<'a> Parser<'a> {
         }
         Ok(Self {
             tokens,
+            comments,
             pos: 0,
             source,
         })
@@ -470,13 +474,46 @@ fn desugar_question(expr: Expr, span: Span) -> Expr {
 
 /// Parse a source string into a list of top-level expressions.
 pub fn parse(source: &str) -> Result<Vec<Expr>, ParseError> {
+    parse_with_comments(source).map(|(exprs, _)| exprs)
+}
+
+/// Parse a source string into top-level expressions and a list of comments
+/// captured at lex time. The formatter uses the comments to put them back in
+/// the output; everything else can keep using `parse`.
+pub fn parse_with_comments(source: &str) -> Result<(Vec<Expr>, Vec<Comment>), ParseError> {
     let mut parser = Parser::new(source)?;
-    parser.parse_program()
+    let exprs = parser.parse_program()?;
+    Ok((exprs, parser.comments))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_with_comments_captures_with_spans() {
+        let src = "; head\n[+ 1 2] ; trail\n";
+        let (exprs, comments) = parse_with_comments(src).unwrap();
+        // Grammar untouched: still parses one top-level expression.
+        assert_eq!(exprs.len(), 1);
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].text, "; head");
+        assert_eq!(&src[comments[0].span.start..comments[0].span.end], "; head");
+        assert_eq!(comments[1].text, "; trail");
+        assert_eq!(
+            &src[comments[1].span.start..comments[1].span.end],
+            "; trail"
+        );
+    }
+
+    #[test]
+    fn parse_shim_drops_comments() {
+        // The classic `parse` entry point must not see comments — preserves
+        // every existing caller's contract.
+        let src = "; ignore\n[+ 1 2]\n";
+        let exprs = parse(src).unwrap();
+        assert_eq!(exprs.len(), 1);
+    }
 
     #[test]
     fn parse_hello_world() {

--- a/crates/loon-lang/src/syntax/mod.rs
+++ b/crates/loon-lang/src/syntax/mod.rs
@@ -22,3 +22,11 @@ impl Span {
         }
     }
 }
+
+/// A `;`-style line comment captured by the lexer. The formatter uses these
+/// to put comments back at the right positions; the parser never sees them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Comment {
+    pub span: Span,
+    pub text: String,
+}

--- a/crates/loon-lang/src/syntax/tokens.rs
+++ b/crates/loon-lang/src/syntax/tokens.rs
@@ -63,8 +63,13 @@ fn unescape(s: &str) -> String {
 
 #[derive(Logos, Debug, Clone, PartialEq)]
 #[logos(skip r"[ \t\r\n]+")]
-#[logos(skip r";[^\n]*")]
 pub enum Token {
+    // Line comments. Captured rather than skipped so the formatter can put
+    // them back; the parser routes them into a side table so the grammar
+    // never sees them.
+    #[regex(r";[^\n]*", |lex| lex.slice().to_string())]
+    Comment(String),
+
     // Delimiters
     #[token("[")]
     LBracket,

--- a/crates/loon-lang/tests/fmt_samples.rs
+++ b/crates/loon-lang/tests/fmt_samples.rs
@@ -1,0 +1,103 @@
+//! Integration test: round-trip every `samples/**/*.oo` through the
+//! comment-preserving formatter and assert (a) all comments survive, (b)
+//! formatting is idempotent, and (c) parser output is preserved (same number
+//! of top-level expressions).
+
+use loon_lang::fmt::format_program_with_comments;
+use loon_lang::parser::parse_with_comments;
+use std::path::{Path, PathBuf};
+
+fn samples_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR is .../crates/loon-lang
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .unwrap()
+        .join("samples")
+}
+
+fn collect_oo(root: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(root) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_oo(&path, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("oo") {
+            out.push(path);
+        }
+    }
+}
+
+fn fmt(src: &str) -> String {
+    let (exprs, comments) = parse_with_comments(src).expect("sample failed to parse");
+    format_program_with_comments(&exprs, &comments, src)
+}
+
+#[test]
+fn samples_round_trip_preserves_comments_and_is_idempotent() {
+    let dir = samples_dir();
+    let mut files = Vec::new();
+    collect_oo(&dir, &mut files);
+    assert!(!files.is_empty(), "expected to find samples in {dir:?}");
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for path in &files {
+        let src = std::fs::read_to_string(path).expect("read sample");
+        let (orig_exprs, orig_comments) = match parse_with_comments(&src) {
+            Ok(out) => out,
+            Err(e) => {
+                failures.push(format!("{}: parse failed: {}", path.display(), e.message));
+                continue;
+            }
+        };
+
+        let first = fmt(&src);
+
+        // (a) Comment count preserved.
+        let (_first_exprs, first_comments) = parse_with_comments(&first)
+            .unwrap_or_else(|e| panic!("{} reparsed failed: {}", path.display(), e.message));
+        if first_comments.len() != orig_comments.len() {
+            failures.push(format!(
+                "{}: comment count changed {} -> {}",
+                path.display(),
+                orig_comments.len(),
+                first_comments.len()
+            ));
+        }
+
+        // (b) Top-level expression count preserved (semantic preservation).
+        let (first_exprs2, _) = parse_with_comments(&first).unwrap();
+        if first_exprs2.len() != orig_exprs.len() {
+            failures.push(format!(
+                "{}: top-level expr count changed {} -> {}",
+                path.display(),
+                orig_exprs.len(),
+                first_exprs2.len()
+            ));
+        }
+
+        // (c) Idempotence.
+        let second = fmt(&first);
+        if first != second {
+            // Keep the report compact — full diffs would flood the output.
+            failures.push(format!(
+                "{}: not idempotent ({} bytes -> {} bytes after second format)",
+                path.display(),
+                first.len(),
+                second.len()
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} sample(s) failed round-trip:\n  - {}",
+            failures.len(),
+            failures.join("\n  - ")
+        );
+    }
+}

--- a/crates/loon-lsp/src/lib.rs
+++ b/crates/loon-lsp/src/lib.rs
@@ -125,10 +125,7 @@ impl LanguageServer for LoonLanguageServer {
             return Ok(None);
         };
 
-        Ok(formatting_edits(
-            &doc.rope.to_string(),
-            doc.rope.len_lines() as u32,
-        ))
+        Ok(formatting_edits(&doc.rope.to_string()))
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
@@ -302,13 +299,19 @@ fn classify_completion_kind(ty: &Type) -> CompletionItemKind {
 /// is already formatted or cannot be parsed — an unparseable buffer (e.g. an
 /// in-progress edit saved with format-on-save) should be a silent no-op, not an
 /// error popup.
-fn formatting_edits(source: &str, len_lines: u32) -> Option<Vec<TextEdit>> {
-    let exprs = loon_lang::parser::parse(source).ok()?;
-    let formatted = loon_lang::fmt::format_program(&exprs);
+fn formatting_edits(source: &str) -> Option<Vec<TextEdit>> {
+    let (exprs, comments) = loon_lang::parser::parse_with_comments(source).ok()?;
+    let formatted = loon_lang::fmt::format_program_with_comments(&exprs, &comments, source);
 
     if formatted == source {
         return None;
     }
+
+    // Anchor the edit's end at the true end of the document. Hand-rolling
+    // `{ line: rope.len_lines(), character: 0 }` points one line past EOF
+    // (ropey counts the trailing line); lean on the existing offset helper.
+    let rope = ropey::Rope::from_str(source);
+    let end = offset_to_position(&rope, rope.len_bytes());
 
     Some(vec![TextEdit {
         range: Range {
@@ -316,10 +319,7 @@ fn formatting_edits(source: &str, len_lines: u32) -> Option<Vec<TextEdit>> {
                 line: 0,
                 character: 0,
             },
-            end: Position {
-                line: len_lines,
-                character: 0,
-            },
+            end,
         },
         new_text: formatted,
     }])
@@ -513,23 +513,67 @@ mod tests {
     #[test]
     fn formatting_edits_reformats_unformatted_source() {
         let src = "[let   x    42]";
-        let edits = formatting_edits(src, 1).expect("unformatted source should yield an edit");
+        let edits = formatting_edits(src).expect("unformatted source should yield an edit");
         assert_eq!(edits.len(), 1);
         assert_ne!(edits[0].new_text, src);
         // The replacement must be itself stable (idempotent formatter output).
-        assert!(formatting_edits(&edits[0].new_text, 1).is_none());
+        assert!(formatting_edits(&edits[0].new_text).is_none());
     }
 
     #[test]
     fn formatting_edits_noop_when_already_formatted() {
         let src = loon_lang::fmt::format_program(&loon_lang::parser::parse("[let x 42]").unwrap());
-        assert!(formatting_edits(&src, 1).is_none());
+        assert!(formatting_edits(&src).is_none());
     }
 
     #[test]
     fn formatting_edits_silent_on_parse_error() {
         // Unparseable buffer must be a no-op, not an error popup.
-        assert!(formatting_edits("[let x", 1).is_none());
+        assert!(formatting_edits("[let x").is_none());
+    }
+
+    #[test]
+    fn formatting_edit_range_spans_to_true_eof() {
+        // Source with no trailing newline: the edit's end must be the real
+        // end-of-document (line 0, col = len), not a line past EOF.
+        let src = "[let   x   42]";
+        let edits = formatting_edits(src).unwrap();
+        assert_eq!(edits[0].range.start, Position::new(0, 0));
+        assert_eq!(edits[0].range.end, Position::new(0, src.len() as u32));
+    }
+
+    #[test]
+    fn formatting_edit_round_trips_when_applied() {
+        // Applying the produced edit to the buffer (resolving its range the
+        // same way a client does) must yield exactly the formatter output —
+        // proving the range actually covers the whole document.
+        for src in ["[let   x   42]", "[let x 1]\n[let   y   2]\n"] {
+            let edits = formatting_edits(src).unwrap();
+            let edit = &edits[0];
+            let rope = ropey::Rope::from_str(src);
+            let start = position_to_offset(&rope, edit.range.start);
+            let end = position_to_offset(&rope, edit.range.end);
+            let mut bytes = src.as_bytes().to_vec();
+            bytes.splice(start..end, edit.new_text.bytes());
+            let applied = String::from_utf8(bytes).unwrap();
+            let (exprs, comments) = loon_lang::parser::parse_with_comments(src).unwrap();
+            let expected = loon_lang::fmt::format_program_with_comments(&exprs, &comments, src);
+            assert_eq!(applied, expected);
+        }
+    }
+
+    #[test]
+    fn formatting_preserves_comments() {
+        // The whole reason for this rewrite: format-on-save must not destroy
+        // user comments. Both leading and trailing forms.
+        let src = "; header\n[let   x   42] ; the answer\n";
+        let edits = formatting_edits(src).expect("should produce an edit");
+        let new_text = &edits[0].new_text;
+        assert!(new_text.contains("; header"), "leading comment lost:\n{new_text}");
+        assert!(
+            new_text.contains("; the answer"),
+            "trailing comment lost:\n{new_text}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The Loon formatter currently deletes every `;` comment in the file because the lexer discards them at the logos `skip` attribute. With `document_formatting_provider` from #8 now merged, format-on-save silently shreds user comments — verified empirically: physics.oo loses 28, tco-stress.oo loses 13, bench-collections.oo loses 9. This PR captures comments at lex time and re-attaches them by source position during formatting, fixes the match-arm collapse bug, preserves user blank lines between forms, and corrects two latent LSP issues that were prepared as a follow-up to #8 but missed the merge.

## What changed

**`crates/loon-lang/src/syntax/tokens.rs`** — drop `#[logos(skip r";[^\n]*")]`; add a `Comment(String)` logos token. Comments now reach the lexer output instead of being thrown away.

**`crates/loon-lang/src/syntax/mod.rs`** — `pub struct Comment { span: Span, text: String }`. Reuses the existing byte-offset `Span`.

**`crates/loon-lang/src/parser/mod.rs`** — `Parser` gains a `comments` side vec; the lex loop routes `Comment` tokens into it so the grammar never sees them. New `pub fn parse_with_comments(source) -> Result<(Vec<Expr>, Vec<Comment>), ParseError>`. Existing `pub fn parse` becomes a one-line shim — every existing caller is unaffected.

**`crates/loon-lang/src/fmt/mod.rs`** — the substantive piece.
- An attachment pre-pass walks the AST with the sorted comment list and produces a `HashMap<NodeId, NodeComments>` (leading / trailing / dangling), plus program-level leading/trailing, plus a `blank_before: HashSet<NodeId>` for nodes whose preceding gap had a blank line in source (capped at one blank line for idempotence).
- A `Ctx<'a> { att, src }` threads through the doc builders. `fmt_children` interleaves comments and blank lines between siblings, choosing `hard_line()` when the previous child has a trailing comment or the next has a leading comment.
- Special-form printers use `body_break(last_header, ctx)` and `close_after(last_body, ctx)` helpers so a trailing comment on a header item (e.g. params in `[fn name [params] ...]`) emits *inside* the indent block — preventing the comment from swallowing the body, and ensuring the right indent on the next line.
- New `pub fn format_program_with_comments(exprs, comments, source) -> String`. Existing `format_program(exprs)` is a back-compat shim.

**Two correctness fixes that fell out of the work:**
- `fits()` now returns `false` on `HardLine` (proper Wadler semantics — was returning `true`, which made `Group` render flat around hard breaks and let comment text swallow following content).
- `match_to_doc` chunks `items[2..]` into `(pat, body)` pairs joined by `hard_line()` instead of soft `line()`, so match arms no longer collapse onto a single line (the fib readability bug).

**`crates/loon-cli/src/main.rs`** — `loon fmt` switches to the new API.

**`crates/loon-lsp/src/lib.rs`** — `formatting_edits` uses `parse_with_comments` + `format_program_with_comments`. Also folds in two improvements prepared as a third commit on #8 that didn't reach the contributor's fork before merge:
- Edit range end now uses `offset_to_position(&rope, rope.len_bytes())` instead of `{ line: rope.len_lines(), character: 0 }`, which pointed one line past EOF (ropey counts the trailing line). It only worked because LSP clients clamp out-of-range positions; a stricter client could reject. Drops the now-unused `len_lines` parameter.
- Three new tests harden the previously unverified parts (range spans true EOF, round-trip when applied, comments preserved).

## Tests

- 488/488 workspace tests pass.
- 9 new fmt unit tests: leading / trailing / EOF / comment-only file / consecutive comments / inside-list / user blank line / multi-blank collapse / match-arm layout.
- 2 new parser tests: `parse_with_comments` captures with correct spans; `parse` shim still drops comments.
- 3 new LSP tests: range spans true EOF, round-trip when applied, comments preserved.
- New integration test `crates/loon-lang/tests/fmt_samples.rs` round-trips every `samples/**/*.oo`: asserts comment count preserved, top-level expression count preserved, and `fmt(fmt(x)) == fmt(x)`. Catches whole classes of bugs the unit tests miss.

## Sample evidence

`samples/physics.oo` before this PR: 28 comments → 0 after `loon fmt`. With this PR: 28 → 28, including trailing same-line comments like `; → Velocity`, and section blank lines preserved.

`samples/fib.oo` before: `[match n 0 0 1 1 n [+ ...]]` collapsed onto one line. After: each `(pattern, body)` pair on its own indented line.

`cargo run -p loon-cli -- run samples/X.oo` produces identical output before/after `loon fmt` on all 14 samples (modulo HashMap iteration order in word-count.oo, which is non-deterministic without any formatting).

## Test plan

- [ ] `cargo test --workspace` passes (488 tests)
- [ ] `cargo run -p loon-cli -- fmt samples/physics.oo` preserves all 28 comments and intentional blank lines between sections
- [ ] `cargo run -p loon-cli -- fmt samples/fib.oo` lays out match arms one per line
- [ ] In an LSP client (Neovim/VS Code) with format-on-save enabled, opening any commented .oo file and saving preserves the comments

## Known v1 limitations (good follow-up issues, not blockers)

- Blank lines purely *between consecutive comments* (within a header comment block) aren't tracked — only blanks between expressions, and between an expression and the following comment, are preserved.
- LSP `FormattingOptions` (tab size, final newline) still ignored. Loon is intentionally a gofmt-style opinionated formatter; should be documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)