### PR TITLE
Add ADTs, loop/recur, keywords, and effects to EIR lowering

### DIFF
--- a/docs/elegance-notes.md
+++ b/docs/elegance-notes.md
@@ -41,6 +41,14 @@ Legend: **break?** = backward-incompatible · **effort** S/M/L.
    loudly. **Fix:** user `fn` (and `let`) bindings shadow builtins; warn on
    shadow. _break? yes (subtle) · effort S_
 
+4c. **`match` does not discriminate constructors across different types.** A
+   pattern `[LCtx a b c d]` happily matched a `[VB s i]` value (a different
+   type, even different arity) — match appears to assume the scrutinee has the
+   pattern's type and only discriminates *within* a type. This silently binds
+   garbage when a heterogeneous collection holds values of several types.
+   **Fix:** match should check the constructor's owning type/tag, not just shape.
+   _break? yes (catches latent bugs) · effort M_
+
 5. **`let` is a body statement, not an expression.** `[let x v]` scopes to the
    rest of the enclosing body — clean in sequences, but `[let …]` can't be used
    as a sub-expression (the lowerer/inferrer special-case it). **Consider:** a

--- a/docs/elegance-notes.md
+++ b/docs/elegance-notes.md
@@ -34,6 +34,13 @@ Legend: **break?** = backward-incompatible · **effort** S/M/L.
    effects must be declared. **Fix:** either declare everything (with a `prelude`
    of standard effects) or document a fixed built-in set. _break? maybe · S_
 
+4b. **Builtins shadow user `fn` definitions.** Defining `[fn sum …]` does *not*
+   override the builtin `sum` — `[sum xs]` still calls the builtin (discovered
+   when a self-hosted test silently computed against the builtin instead of the
+   user's recursive `sum`). User definitions should win, or at least collide
+   loudly. **Fix:** user `fn` (and `let`) bindings shadow builtins; warn on
+   shadow. _break? yes (subtle) · effort S_
+
 5. **`let` is a body statement, not an expression.** `[let x v]` scopes to the
    rest of the enclosing body — clean in sequences, but `[let …]` can't be used
    as a sub-expression (the lowerer/inferrer special-case it). **Consider:** a

--- a/src/frontend/eir.oo
+++ b/src/frontend/eir.oo
@@ -26,7 +26,15 @@
   [OAdt   i64 String Vec]  ; dest <- constructor value (tag + field registers)
   [OTag   i64 i64]         ; dest <- constructor tag (string) of an adt register
   [OField i64 i64 i64]     ; dest <- field #idx of an adt register
+  [OPerform i64 String Vec] ; dest <- perform effect op (name, arg regs)
+  [OHandlePush Vec]        ; push a handler frame (vector of HE)
+  [OHandlePop]             ; pop the top handler frame
   [OMove  i64 i64]]        ; dest <- src register
+
+; A handler-frame entry: an effect operation name -> the index of the synthetic
+; function that handles it. (Desugaring lifts each handler clause to a function;
+; resume is the identity, so handlers are tail-resumptive.)
+[type HE [HE String i64]]
 
 [type Term
   [TRet  i64]              ; return register
@@ -78,6 +86,9 @@
     [OAdt d ctor args] [str "r" d " = " ctor " " [eir-write-regs args]]
     [OTag d s] [str "r" d " = tag r" s]
     [OField d s ix] [str "r" d " = r" s "." ix]
+    [OPerform d nm args] [str "r" d " = perform " nm " " [eir-write-regs args]]
+    [OHandlePush frame] [str "handle-push (" [len frame] ")"]
+    [OHandlePop] "handle-pop"
     [OMove d s]  [str "r" d " = r" s]]]
 
 [fn eir-write-regs [args]

--- a/src/frontend/eir.oo
+++ b/src/frontend/eir.oo
@@ -22,6 +22,9 @@
   [OPrim  i64 String Vec]  ; dest <- primitive op applied to arg registers
   [OCall  i64 i64 Vec]     ; dest <- call func #idx with arg registers
   [OVec   i64 Vec]         ; dest <- vector built from arg registers
+  [OAdt   i64 String Vec]  ; dest <- constructor value (tag + field registers)
+  [OTag   i64 i64]         ; dest <- constructor tag (string) of an adt register
+  [OField i64 i64 i64]     ; dest <- field #idx of an adt register
   [OMove  i64 i64]]        ; dest <- src register
 
 [type Term
@@ -70,6 +73,9 @@
     [OPrim d nm args] [str "r" d " = " nm " " [eir-write-regs args]]
     [OCall d fi args] [str "r" d " = call #" fi " " [eir-write-regs args]]
     [OVec d args] [str "r" d " = vec " [eir-write-regs args]]
+    [OAdt d ctor args] [str "r" d " = " ctor " " [eir-write-regs args]]
+    [OTag d s] [str "r" d " = tag r" s]
+    [OField d s ix] [str "r" d " = r" s "." ix]
     [OMove d s]  [str "r" d " = r" s]]]
 
 [fn eir-write-regs [args]

--- a/src/frontend/eir.oo
+++ b/src/frontend/eir.oo
@@ -29,6 +29,8 @@
   [OPerform i64 String Vec] ; dest <- perform effect op (name, arg regs)
   [OHandlePush Vec]        ; push a handler frame (vector of HE)
   [OHandlePop]             ; pop the top handler frame
+  [OClosure i64 i64 Vec]   ; dest <- closure over func #idx capturing the given regs
+  [OCallV i64 i64 Vec]     ; dest <- call the closure in a register with arg regs
   [OMove  i64 i64]]        ; dest <- src register
 
 ; A handler-frame entry: an effect operation name -> the index of the synthetic
@@ -89,6 +91,8 @@
     [OPerform d nm args] [str "r" d " = perform " nm " " [eir-write-regs args]]
     [OHandlePush frame] [str "handle-push (" [len frame] ")"]
     [OHandlePop] "handle-pop"
+    [OClosure d fi caps] [str "r" d " = closure #" fi " [" [eir-write-regs caps] "]"]
+    [OCallV d fr args] [str "r" d " = call-v r" fr " " [eir-write-regs args]]
     [OMove d s]  [str "r" d " = r" s]]]
 
 [fn eir-write-regs [args]

--- a/src/frontend/eir.oo
+++ b/src/frontend/eir.oo
@@ -18,6 +18,7 @@
   [OFloat i64 String]      ; dest <- float literal
   [OStr   i64 String]      ; dest <- string literal
   [OBool  i64 Bool]        ; dest <- bool literal
+  [OKw    i64 String]      ; dest <- keyword literal (:name, stored without colon)
   [OUnit  i64]             ; dest <- ()
   [OPrim  i64 String Vec]  ; dest <- primitive op applied to arg registers
   [OCall  i64 i64 Vec]     ; dest <- call func #idx with arg registers
@@ -69,6 +70,7 @@
     [OFloat d s] [str "r" d " = float " s]
     [OStr d s]   [str "r" d " = str " [ch-quote] s [ch-quote]]
     [OBool d b]  [str "r" d " = bool " [if b "true" "false"]]
+    [OKw d n]    [str "r" d " = :" n]
     [OUnit d]    [str "r" d " = ()"]
     [OPrim d nm args] [str "r" d " = " nm " " [eir-write-regs args]]
     [OCall d fi args] [str "r" d " = call #" fi " " [eir-write-regs args]]

--- a/src/frontend/lower.oo
+++ b/src/frontend/lower.oo
@@ -41,11 +41,29 @@
 
 ; ── Lexical environment (name -> register) ───────────────────────────────────
 
-[type VB [VB String i64]]
+; Environment entries. A variable binding (name -> register) and a loop context
+; (header block, result register, join block, loop-variable registers) are
+; variants of ONE type so `match` discriminates them reliably — Loon's match
+; does not distinguish constructors across *different* types, only within a
+; type, so the loop context must share a type with variable bindings to ride
+; along in the same environment vector.
+[type Env
+  [VB String i64]
+  [LCtx i64 i64 i64 Vec]]
+
 [fn lenv-lookup [env name]
   [loop [k [- [len env] 1]]
     [if [< k 0] -1
-      [match [nth env k] [VB n r] [if [streq n name] r [recur [- k 1]]]]]]]
+      [match [nth env k]
+        [VB n r] [if [streq n name] r [recur [- k 1]]]
+        _ [recur [- k 1]]]]]]
+
+[fn find-loop-ctx [env]
+  [loop [k [- [len env] 1]]
+    [if [< k 0] :none
+      [match [nth env k]
+        [LCtx a b c d] [nth env k]
+        _ [recur [- k 1]]]]]]
 
 ; ── Function table (name -> index, in definition order) ──────────────────────
 
@@ -105,15 +123,21 @@
   [if [= [len items] 0]
     [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]
     [match [nth items 0]
-      [FSym h _ _]
-      [if [streq h "if"] [lower-if env fns ls items]
-        [if [streq h "match"] [lower-match env fns ls items]
-          [if [streq h "do"] [lower-seq env fns ls [eir-vec-rest items 1]]
-            [if [streq h "let"] [lower-seq env fns ls #[[FList items [Span 0 0]]]]  ; bare let-expr
+      [FSym h _ _] [lower-form env fns ls items h]
+      _ [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]]]]
+
+; Dispatch a list whose head is a symbol: special forms, then constructor
+; application (capitalized head), then primitive / user calls.
+[fn lower-form [env fns ls items h]
+  [if [streq h "if"] [lower-if env fns ls items]
+    [if [streq h "match"] [lower-match env fns ls items]
+      [if [streq h "do"] [lower-seq env fns ls [eir-vec-rest items 1]]
+        [if [streq h "loop"] [lower-loop env fns ls items]
+          [if [streq h "recur"] [lower-recur env fns ls [eir-vec-rest items 1]]
+            [if [streq h "let"] [lower-seq env fns ls #[[FList items [Span 0 0]]]]
               [if [upper-head? h]
                 [lower-ctor env fns ls h [eir-vec-rest items 1]]
-                [lower-call env fns ls h [eir-vec-rest items 1]]]]]]]
-      _ [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]]]]
+                [lower-call env fns ls h [eir-vec-rest items 1]]]]]]]]]]
 
 ; A capitalized head is a constructor (Loon convention); lower the field
 ; expressions and build a tagged value.
@@ -126,6 +150,84 @@
 [fn upper-head? [s]
   [if [= [len s] 0] false
     [>= [index-of "ABCDEFGHIJKLMNOPQRSTUVWXYZ" [nth [to-chars s] 0]] 0]]]
+
+; loop / recur — tail-recursive iteration.
+;
+; [loop [v0 i0 v1 i1 …] body…] seeds one register per loop variable with its
+; init, jumps to a header block, and lowers the body there; the body's value
+; (the non-recur path) becomes the loop's result. [recur a0 a1 …] evaluates its
+; arguments into temporaries, moves them into the loop-variable registers, and
+; jumps back to the header. The loop context (header/result/join/var-regs) rides
+; in the environment so recur can find the innermost enclosing loop.
+[type LI [LI Vec Vec LS]]   ; loop-var names, their registers, threaded state
+
+[fn lower-loop [env fns ls items]
+  [match [nth items 1] [FList binds _]
+    [match [eval-loop-inits env fns ls binds]
+      [LI names varregs ls1]
+      [match [ls-block ls1] [RP headerb ls2]
+      [match [ls-block ls2] [RP joinb ls3]
+      [match [ls-reg ls3]   [RP dest ls4]
+        [lower-loop-body env fns
+          [ls-start [ls-finish ls4 [TBr headerb]] headerb]
+          items names varregs headerb dest joinb]]]]]
+    _ [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]]]
+
+; Evaluate each init (in the outer scope) into its loop-variable register.
+[fn eval-loop-inits [env fns ls binds]
+  [loop [k 0 ls ls names #[] regs #[]]
+    [if [>= k [len binds]]
+      [LI names regs ls]
+      [match [nth binds k]
+        [FSym nm _ _]
+        [match [lower-expr env fns ls [nth binds [+ k 1]]]
+          [RP r ls1] [recur [+ k 2] ls1 [conj names nm] [conj regs r]]]
+        _ [LI names regs ls]]]]]
+
+[fn lower-loop-body [env fns ls items names varregs headerb dest joinb]
+  [match [lower-seq [bind-loop-vars [conj env [LCtx headerb dest joinb varregs]] names varregs]
+            fns ls [eir-vec-rest items 2]]
+    [RP rr ls1]
+    [RP dest [ls-start [ls-finish [ls-emit ls1 [OMove dest rr]] [TBr joinb]] joinb]]]]
+
+[fn bind-loop-vars [env names varregs]
+  [loop [k 0 env env]
+    [if [>= k [len names]] env
+      [recur [+ k 1] [conj env [VB [nth names k] [nth varregs k]]]]]]]
+
+[fn lower-recur [env fns ls args]
+  [match [find-loop-ctx env]
+    :none [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]
+    [LCtx headerb dest joinb varregs]
+    [match [lower-recur-args env fns ls args]
+      [RPS temps ls1]
+      [lower-recur-jump [emit-recur-moves ls1 varregs temps] headerb]]]]
+
+; Lower each recur argument into a FRESH temporary register. A bare variable
+; argument lowers to the variable's own register, which may be a loop-variable
+; register; forcing a copy ensures the temporaries never alias the loop
+; variables, so the subsequent moves can't clobber (e.g. recur b a swaps).
+[fn lower-recur-args [env fns ls args]
+  [loop [k 0 ls ls acc #[]]
+    [if [>= k [len args]]
+      [RPS acc ls]
+      [match [lower-expr env fns ls [nth args k]]
+        [RP r ls1]
+        [match [ls-reg ls1] [RP t ls2]
+          [recur [+ k 1] [ls-emit ls2 [OMove t r]] [conj acc t]]]]]]]
+
+; Move each evaluated argument into its loop-variable register.
+[fn emit-recur-moves [ls varregs temps]
+  [loop [k 0 ls ls]
+    [if [>= k [len varregs]] ls
+      [recur [+ k 1] [ls-emit ls [OMove [nth varregs k] [nth temps k]]]]]]]
+
+; Jump back to the header, then open a fresh (unreachable) block so the
+; enclosing expression still has a well-formed block to emit into.
+[fn lower-recur-jump [ls headerb]
+  [match [ls-block [ls-finish ls [TBr headerb]]] [RP deadb ls1]
+    [match [ls-reg [ls-start ls1 deadb]] [RP d ls2]
+      [RP d [ls-emit ls2 [OUnit d]]]]]]
 
 ; A call to a primitive or a user function.
 [fn lower-call [env fns ls h args]

--- a/src/frontend/lower.oo
+++ b/src/frontend/lower.oo
@@ -125,7 +125,16 @@
     [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]
     [match [nth items 0]
       [FSym h _ _] [lower-form env fns ls items h]
+      [FDot [FSym eff _ _] fld _]
+      [lower-perform env fns ls [str eff "." fld] [eir-vec-rest items 1]]
       _ [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]]]]
+
+; A perform site [Eff.op args…] (dotted head) dispatches dynamically to the
+; installed handler at run time.
+[fn lower-perform [env fns ls opname args]
+  [match [lower-args env fns ls args]
+    [RPS regs ls1]
+    [match [ls-reg ls1] [RP d ls2] [RP d [ls-emit ls2 [OPerform d opname regs]]]]]]
 
 ; Dispatch a list whose head is a symbol: special forms, then constructor
 ; application (capitalized head), then primitive / user calls.
@@ -136,9 +145,30 @@
         [if [streq h "loop"] [lower-loop env fns ls items]
           [if [streq h "recur"] [lower-recur env fns ls [eir-vec-rest items 1]]
             [if [streq h "let"] [lower-seq env fns ls #[[FList items [Span 0 0]]]]
-              [if [upper-head? h]
-                [lower-ctor env fns ls h [eir-vec-rest items 1]]
-                [lower-call env fns ls h [eir-vec-rest items 1]]]]]]]]]]
+              [if [streq h "handle"] [lower-handle env fns ls items]
+                [if [streq h "resume"] [lower-expr env fns ls [nth items 1]]
+                  [if [upper-head? h]
+                    [lower-ctor env fns ls h [eir-vec-rest items 1]]
+                    [lower-call env fns ls h [eir-vec-rest items 1]]]]]]]]]]]]
+
+; handle: after desugaring, the form is [handle body [opname fnname]…]. Install a
+; handler frame (resolving handler function names to indices) for the dynamic
+; extent of the body, then pop it. The body's value is the handle's value.
+[fn lower-handle [env fns ls items]
+  [match [lower-expr env fns [ls-emit ls [OHandlePush [build-frame fns items 2]]] [nth items 1]]
+    [RP bodyreg ls1]
+    [RP bodyreg [ls-emit ls1 [OHandlePop]]]]]
+
+[fn build-frame [fns items i]
+  [loop [k i acc #[]]
+    [if [>= k [len items]] acc
+      [match [nth items k] [FList pair _]
+        [match [nth pair 0] [FSym opname _ _]
+          [match [nth pair 1] [FSym fnname _ _]
+            [recur [+ k 1] [conj acc [HE opname [fn-index fns fnname]]]]
+            _ [recur [+ k 1] acc]]
+          _ [recur [+ k 1] acc]]
+        _ [recur [+ k 1] acc]]]]]
 
 ; A capitalized head is a constructor (Loon convention); lower the field
 ; expressions and build a tagged value.
@@ -457,7 +487,8 @@
         [FSym pn _ _] [recur [+ k 1] [conj acc [VB pn k]]]
         _ [recur [+ k 1] acc]]]]]
 
-[fn lower-program [forms]
+[fn lower-program [forms0]
+  [let forms [desugar-program forms0]]    ; lift handle clauses to synthetic fns
   [let fns [build-fntab forms]]
   [Module
     [loop [k 0 acc #[]]
@@ -465,3 +496,114 @@
         [match [lower-fn-def? [nth forms k]]
           :no [recur [+ k 1] acc]
           items [recur [+ k 1] [conj acc [lower-fn fns items]]]]]]]]
+
+; ── Desugaring: lift handler clauses to top-level synthetic functions ────────
+;
+; [handle body [Eff.op p…] res …] becomes [handle body [<opname> <fn>] …] with
+; one synthetic [fn <fn> [p…] res'] appended per clause, where res' has resume
+; stripped to the identity. This lets handlers be ordinary functions callable by
+; index from a perform site, and keeps lowering oblivious to handler scoping.
+; (Reader handlers don't capture enclosing scope, so the lifted functions need
+; only the operation arguments as parameters.)
+[type DR  [DR Form i64 Vec]]    ; desugared form, next counter, accumulated fns
+[type DRI [DRI Vec i64 Vec]]    ; desugared items, next counter, accumulated fns
+
+[fn desugar-program [forms]
+  [loop [k 0 counter 0 out #[] extras #[]]
+    [if [>= k [len forms]]
+      [vconcat out extras]
+      [match [desugar-expr [nth forms k] counter extras]
+        [DR f2 c2 e2] [recur [+ k 1] c2 [conj out f2] e2]]]]]
+
+[fn desugar-expr [f counter extras]
+  [match f
+    [FList items _]
+    [if [if [> [len items] 0] [is-sym? [nth items 0] "handle"] false]
+      [desugar-handle items counter extras]
+      [match [desugar-items items counter extras]
+        [DRI items2 c2 e2] [DR [FList items2 [Span 0 0]] c2 e2]]]
+    [FVec items sp]   [desugar-coll-vec items sp counter extras]
+    [FSet items sp]   [desugar-coll-set items sp counter extras]
+    [FTuple items sp] [desugar-coll-tuple items sp counter extras]
+    [FMap items sp]   [desugar-coll-map items sp counter extras]
+    [FDot b fld sp]   [match [desugar-expr b counter extras] [DR b2 c2 e2] [DR [FDot b2 fld sp] c2 e2]]
+    [FQuery x sp]     [match [desugar-expr x counter extras] [DR x2 c2 e2] [DR [FQuery x2 sp] c2 e2]]
+    _ [DR f counter extras]]]
+
+[fn desugar-items [items counter extras]
+  [loop [k 0 counter counter extras extras acc #[]]
+    [if [>= k [len items]]
+      [DRI acc counter extras]
+      [match [desugar-expr [nth items k] counter extras]
+        [DR f2 c2 e2] [recur [+ k 1] c2 e2 [conj acc f2]]]]]]
+
+[fn desugar-coll-vec [items sp counter extras]
+  [match [desugar-items items counter extras] [DRI i2 c2 e2] [DR [FVec i2 sp] c2 e2]]]
+[fn desugar-coll-set [items sp counter extras]
+  [match [desugar-items items counter extras] [DRI i2 c2 e2] [DR [FSet i2 sp] c2 e2]]]
+[fn desugar-coll-tuple [items sp counter extras]
+  [match [desugar-items items counter extras] [DRI i2 c2 e2] [DR [FTuple i2 sp] c2 e2]]]
+[fn desugar-coll-map [items sp counter extras]
+  [match [desugar-items items counter extras] [DRI i2 c2 e2] [DR [FMap i2 sp] c2 e2]]]
+
+; [handle body pat1 res1 pat2 res2 …] -> [handle body' [op1 fn1] [op2 fn2] …]
+; plus a synthetic fn per clause.
+[fn desugar-handle [items counter extras]
+  [match [desugar-expr [nth items 1] counter extras]
+    [DR body2 c1 e1]
+    [desugar-clauses body2 items 2 c1 e1 #[]]]]
+
+[fn desugar-clauses [body items i counter extras frame]
+  [if [>= i [len items]]
+    [DR [FList [vconcat #[[FSym "handle" #[] [Span 0 0]] body] frame] [Span 0 0]] counter extras]
+    [desugar-clause body items i counter extras frame]]]
+
+[fn desugar-clause [body items i counter extras frame]
+  [match [nth items i] [FList pitems _]
+    [match [desugar-expr [nth items [+ i 1]] counter extras]
+      [DR res2 c2 e2]
+      [desugar-clause2 body items i c2 e2 frame
+        [clause-opname pitems] [eir-vec-rest pitems 1] [strip-resume res2]]]
+    _ [desugar-clauses body items [+ i 2] counter extras frame]]]   ; malformed: skip
+
+[fn desugar-clause2 [body items i counter extras frame opname params res]
+  [desugar-clauses body items [+ i 2] [+ counter 1]
+    [conj extras [build-fn-form [str "$h" counter] params res]]
+    [conj frame [FList #[[FSym opname #[] [Span 0 0]] [FSym [str "$h" counter] #[] [Span 0 0]]] [Span 0 0]]]]]
+
+[fn clause-opname [pitems]
+  [match [nth pitems 0]
+    [FDot [FSym eff _ _] fld _] [str eff "." fld]
+    [FSym n _ _] n
+    _ "?"]]
+
+; Replace [resume x] with x (handlers are tail-resumptive: resume is identity).
+[fn strip-resume [f]
+  [match f
+    [FList items sp]
+    [if [if [> [len items] 0] [is-sym? [nth items 0] "resume"] false]
+      [strip-resume [nth items 1]]
+      [FList [smap-strip items] sp]]
+    [FVec items sp]   [FVec [smap-strip items] sp]
+    [FSet items sp]   [FSet [smap-strip items] sp]
+    [FTuple items sp] [FTuple [smap-strip items] sp]
+    [FMap items sp]   [FMap [smap-strip items] sp]
+    [FDot b fld sp]   [FDot [strip-resume b] fld sp]
+    [FQuery x sp]     [FQuery [strip-resume x] sp]
+    _ f]]
+
+[fn smap-strip [items]
+  [loop [k 0 acc #[]]
+    [if [>= k [len items]] acc [recur [+ k 1] [conj acc [strip-resume [nth items k]]]]]]]
+
+[fn is-sym? [f name]
+  [match f [FSym n _ _] [streq n name] _ false]]
+
+[fn build-fn-form [name params res]
+  [FList
+    #[[FSym "fn" #[] [Span 0 0]] [FSym name #[] [Span 0 0]] [FList params [Span 0 0]] res]
+    [Span 0 0]]]
+
+[fn vconcat [a b]
+  [loop [k 0 acc a]
+    [if [>= k [len b]] acc [recur [+ k 1] [conj acc [nth b k]]]]]]

--- a/src/frontend/lower.oo
+++ b/src/frontend/lower.oo
@@ -110,8 +110,22 @@
         [if [streq h "match"] [lower-match env fns ls items]
           [if [streq h "do"] [lower-seq env fns ls [eir-vec-rest items 1]]
             [if [streq h "let"] [lower-seq env fns ls #[[FList items [Span 0 0]]]]  ; bare let-expr
-              [lower-call env fns ls h [eir-vec-rest items 1]]]]]]
+              [if [upper-head? h]
+                [lower-ctor env fns ls h [eir-vec-rest items 1]]
+                [lower-call env fns ls h [eir-vec-rest items 1]]]]]]]
       _ [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]]]]
+
+; A capitalized head is a constructor (Loon convention); lower the field
+; expressions and build a tagged value.
+[fn lower-ctor [env fns ls ctor args]
+  [match [lower-args env fns ls args]
+    [RPS regs ls1]
+    [match [ls-reg ls1] [RP d ls2] [RP d [ls-emit ls2 [OAdt d ctor regs]]]]]]
+
+; True when a symbol begins with an uppercase letter (a constructor name).
+[fn upper-head? [s]
+  [if [= [len s] 0] false
+    [>= [index-of "ABCDEFGHIJKLMNOPQRSTUVWXYZ" [nth [to-chars s] 0]] 0]]]
 
 ; A call to a primitive or a user function.
 [fn lower-call [env fns ls h args]
@@ -178,7 +192,65 @@
     [RP dest [ls-start [ls-finish [ls-emit ls [OUnit dest]] [TBr joinb]] joinb]]
     [if [pat-var? [nth items i]]
       [lower-arm-var env fns ls [nth items i] [nth items [+ i 1]] sreg dest joinb]
-      [lower-arm-lit env fns ls items i sreg dest joinb]]]]
+      [if [pat-ctor? [nth items i]]
+        [lower-arm-ctor env fns ls items i sreg dest joinb]
+        [lower-arm-lit env fns ls items i sreg dest joinb]]]]]
+
+; A constructor pattern: [Ctor sub0 sub1 …] (capitalized head). Tests the
+; scrutinee's tag against the constructor name, then on match extracts each
+; field into a register and binds variable/wildcard subpatterns. (Subpatterns
+; must be variables or `_`; nested literal/constructor subpatterns are a later
+; increment.)
+[type BF [BF Vec LS]]
+
+[fn pat-ctor? [pat]
+  [match pat
+    [FList pitems _]
+    [if [= [len pitems] 0] false
+      [match [nth pitems 0] [FSym n _ _] [upper-head? n] _ false]]
+    _ false]]
+
+[fn lower-arm-ctor [env fns ls items i sreg dest joinb]
+  [match [nth items i] [FList pitems _]
+    [match [nth pitems 0] [FSym ctor _ _]
+      [match [ls-reg ls] [RP tagreg ls1]
+      [match [ls-reg [ls-emit ls1 [OTag tagreg sreg]]] [RP litreg ls2]
+      [match [ls-reg [ls-emit ls2 [OStr litreg ctor]]] [RP cmp ls3]
+        [lower-arm-ctor3 env fns [ls-emit ls3 [OPrim cmp "=" #[tagreg litreg]]]
+          items i sreg dest joinb pitems cmp]]]]
+      _ [lower-arm-lit env fns ls items i sreg dest joinb]]]]
+
+[fn lower-arm-ctor3 [env fns ls items i sreg dest joinb pitems cmp]
+  [match [ls-block ls] [RP bodyb ls1]
+  [match [ls-block ls1] [RP nextb ls2]
+    [lower-arm-ctor4 env fns
+      [ls-start [ls-finish ls2 [TBrIf cmp bodyb nextb]] bodyb]
+      items i sreg dest joinb pitems nextb]]]]
+
+[fn lower-arm-ctor4 [env fns ls items i sreg dest joinb pitems nextb]
+  [match [bind-fields env ls sreg pitems]
+    [BF env2 ls1]
+    [match [lower-expr env2 fns ls1 [nth items [+ i 1]]]
+      [RP rr ls2]
+      [lower-arms env fns
+        [ls-start [ls-finish [ls-emit ls2 [OMove dest rr]] [TBr joinb]] nextb]
+        items [+ i 2] sreg dest joinb]]]]
+
+; Extract each field of the scrutinee into a fresh register and bind named
+; subpatterns; returns the extended environment and threaded state.
+[fn bind-fields [env ls sreg pitems]
+  [loop [k 1 fi 0 env env ls ls]
+    [if [>= k [len pitems]]
+      [BF env ls]
+      [match [ls-reg ls] [RP fr ls1]
+        [recur [+ k 1] [+ fi 1]
+          [extend-field-env env [nth pitems k] fr]
+          [ls-emit ls1 [OField fr sreg fi]]]]]]]
+
+[fn extend-field-env [env sub fr]
+  [match sub
+    [FSym n _ _] [if [streq n "_"] env [if [upper-head? n] env [conj env [VB n fr]]]]
+    _ env]]
 
 ; A variable/wildcard arm: bind (unless "_") and lower the body; terminal.
 [fn lower-arm-var [env fns ls pat result sreg dest joinb]

--- a/src/frontend/lower.oo
+++ b/src/frontend/lower.oo
@@ -97,6 +97,7 @@
     [FInt lex _]   [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OInt d lex]]]]
     [FFloat lex _] [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OFloat d lex]]]]
     [FStr v _]     [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OStr d v]]]]
+    [FKw v _]      [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OKw d v]]]]
     [FSym n _ _]   [lower-sym env ls n]
     [FList items _] [lower-list env fns ls items]
     [FVec items _] [lower-vec env fns ls items]
@@ -392,6 +393,7 @@
   [match pat
     [FInt lex _]  [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OInt d lex]]]]
     [FStr v _]    [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OStr d v]]]]
+    [FKw v _]     [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OKw d v]]]]
     [FSym n _ _]  [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OBool d [streq n "true"]]]]]
     _ [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]]]
 

--- a/src/frontend/lower.oo
+++ b/src/frontend/lower.oo
@@ -14,30 +14,40 @@
 
 ; ── Builder state ───────────────────────────────────────────────────────────
 
-[type LS  [LS i64 i64 Vec i64 Vec]]   ; next-reg, next-block, blocks, cur-id, cur-ops
+; next-reg, next-block, blocks, cur-id, cur-ops, lifted-funcs, base.
+; `lifted` accumulates closure functions lifted out of lambdas; `base` is the
+; number of top-level functions (so a lifted closure's index is base + its
+; position in `lifted`). Both thread through the whole lowering of a program.
+[type LS  [LS i64 i64 Vec i64 Vec Vec i64]]
 [type RP  [RP i64 LS]]                 ; an int result (reg/block id) + state
 [type RPS [RPS Vec LS]]                ; a vector of regs + state
 
-[fn ls-init [nparams] [LS nparams 1 #[] 0 #[]]]   ; entry block is id 0
-[fn ls-nregs [ls] [match ls [LS nr _ _ _ _] nr]]
-[fn ls-blocks [ls] [match ls [LS _ _ bl _ _] bl]]
+[fn ls-init [nparams lifted base] [LS nparams 1 #[] 0 #[] lifted base]]
+[fn ls-nregs [ls] [match ls [LS nr _ _ _ _ _ _] nr]]
+[fn ls-blocks [ls] [match ls [LS _ _ bl _ _ _ _] bl]]
+[fn ls-lifted [ls] [match ls [LS _ _ _ _ _ lf _] lf]]
+[fn ls-base [ls] [match ls [LS _ _ _ _ _ _ b] b]]
 
 [fn ls-reg [ls]
-  [match ls [LS nr nb bl ci co] [RP nr [LS [+ nr 1] nb bl ci co]]]]
+  [match ls [LS nr nb bl ci co lf b] [RP nr [LS [+ nr 1] nb bl ci co lf b]]]]
 
 [fn ls-block [ls]
-  [match ls [LS nr nb bl ci co] [RP nb [LS nr [+ nb 1] bl ci co]]]]
+  [match ls [LS nr nb bl ci co lf b] [RP nb [LS nr [+ nb 1] bl ci co lf b]]]]
 
 [fn ls-emit [ls op]
-  [match ls [LS nr nb bl ci co] [LS nr nb bl ci [conj co op]]]]
+  [match ls [LS nr nb bl ci co lf b] [LS nr nb bl ci [conj co op] lf b]]]
 
 ; Finish the current block with `term` (push it to the completed list).
 [fn ls-finish [ls term]
-  [match ls [LS nr nb bl ci co] [LS nr nb [conj bl [Block ci co term]] ci co]]]
+  [match ls [LS nr nb bl ci co lf b] [LS nr nb [conj bl [Block ci co term]] ci co lf b]]]
 
 ; Start filling a fresh block `bid` (empty ops).
 [fn ls-start [ls bid]
-  [match ls [LS nr nb bl _ _] [LS nr nb bl bid #[]]]]
+  [match ls [LS nr nb bl _ _ lf b] [LS nr nb bl bid #[] lf b]]]
+
+; Replace the lifted-functions accumulator (used to merge nested closures back).
+[fn ls-with-lifted [ls lifted]
+  [match ls [LS nr nb bl ci co _ b] [LS nr nb bl ci co lifted b]]]
 
 ; ── Lexical environment (name -> register) ───────────────────────────────────
 
@@ -127,7 +137,16 @@
       [FSym h _ _] [lower-form env fns ls items h]
       [FDot [FSym eff _ _] fld _]
       [lower-perform env fns ls [str eff "." fld] [eir-vec-rest items 1]]
-      _ [match [ls-reg ls] [RP d ls1] [RP d [ls-emit ls1 [OUnit d]]]]]]]
+      _ [lower-callexpr env fns ls items]]]]   ; head is an expression: indirect call
+
+; An indirect call where the head is an arbitrary expression evaluating to a
+; closure, e.g. [[mk 100] 7].
+[fn lower-callexpr [env fns ls items]
+  [match [lower-expr env fns ls [nth items 0]]
+    [RP fr ls1]
+    [match [lower-args env fns ls1 [eir-vec-rest items 1]]
+      [RPS regs ls2]
+      [match [ls-reg ls2] [RP d ls3] [RP d [ls-emit ls3 [OCallV d fr regs]]]]]]]
 
 ; A perform site [Eff.op args…] (dotted head) dispatches dynamically to the
 ; installed handler at run time.
@@ -147,9 +166,10 @@
             [if [streq h "let"] [lower-seq env fns ls #[[FList items [Span 0 0]]]]
               [if [streq h "handle"] [lower-handle env fns ls items]
                 [if [streq h "resume"] [lower-expr env fns ls [nth items 1]]
-                  [if [upper-head? h]
-                    [lower-ctor env fns ls h [eir-vec-rest items 1]]
-                    [lower-call env fns ls h [eir-vec-rest items 1]]]]]]]]]]]]
+                  [if [streq h "fn"] [lower-lambda env fns ls items]
+                    [if [upper-head? h]
+                      [lower-ctor env fns ls h [eir-vec-rest items 1]]
+                      [lower-call env fns ls h [eir-vec-rest items 1]]]]]]]]]]]]]
 
 ; handle: after desugaring, the form is [handle body [opname fnname]…]. Install a
 ; handler frame (resolving handler function names to indices) for the dynamic
@@ -181,6 +201,60 @@
 [fn upper-head? [s]
   [if [= [len s] 0] false
     [>= [index-of "ABCDEFGHIJKLMNOPQRSTUVWXYZ" [nth [to-chars s] 0]] 0]]]
+
+; ── Closures (anonymous fn) ──────────────────────────────────────────────────
+;
+; [fn [params…] body…] is lifted to a top-level synthetic function whose leading
+; parameters are the captured variables (every local binding in scope — the env
+; is already accurate, so over-capture is the worst case and is harmless),
+; followed by the lambda's own parameters. The lambda expression itself becomes
+; an OClosure capturing the current registers of those variables; a call then
+; prepends the captured values to the arguments (call-closure in the VM).
+[type CAP [CAP Vec Vec]]    ; capture names, capture registers
+[type FNR [FNR Func Vec]]   ; a lowered Func + the updated lifted accumulator
+
+[fn lower-lambda [env fns ls items]
+  [match [env-captures env] [CAP cnames cregs]
+    [lower-lambda2 env fns ls items cnames cregs]]]
+
+[fn lower-lambda2 [env fns ls items cnames cregs]
+  [let params [lambda-param-names items]]
+  [let cenv [closure-env cnames params]]
+  [match [lower-fn-body-env "$lam" cenv [+ [len cnames] [len params]]
+            [eir-vec-rest items 2] fns [ls-lifted ls] [ls-base ls]]
+    [FNR lamfunc lifted2]
+    [closure-finish ls [+ [ls-base ls] [len lifted2]] lamfunc lifted2 cregs]]]
+
+[fn closure-finish [ls lamidx lamfunc lifted2 cregs]
+  [match [ls-reg [ls-with-lifted ls [conj lifted2 lamfunc]]]
+    [RP d ls2]
+    [RP d [ls-emit ls2 [OClosure d lamidx cregs]]]]]
+
+; Capture every variable binding currently in scope (skipping loop contexts).
+[fn env-captures [env]
+  [loop [k 0 names #[] regs #[]]
+    [if [>= k [len env]]
+      [CAP names regs]
+      [match [nth env k]
+        [VB n r] [recur [+ k 1] [conj names n] [conj regs r]]
+        _ [recur [+ k 1] names regs]]]]]
+
+; Body environment for a lifted closure: captures occupy registers 0..c-1, the
+; lambda's own parameters c..c+p-1.
+[fn closure-env [cnames params]
+  [vconcat
+    [loop [k 0 acc #[]]
+      [if [>= k [len cnames]] acc [recur [+ k 1] [conj acc [VB [nth cnames k] k]]]]]
+    [loop [j 0 acc #[]]
+      [if [>= j [len params]] acc
+        [recur [+ j 1] [conj acc [VB [nth params j] [+ [len cnames] j]]]]]]]]
+
+[fn lambda-param-names [items]
+  [match [nth items 1] [FList ps _]
+    [loop [k 0 acc #[]]
+      [if [>= k [len ps]] acc
+        [match [nth ps k] [FSym n _ _] [recur [+ k 1] [conj acc n]] _ [recur [+ k 1] acc]]]]
+    _ #[]]]
 
 ; loop / recur — tail-recursive iteration.
 ;
@@ -260,7 +334,9 @@
     [match [ls-reg [ls-start ls1 deadb]] [RP d ls2]
       [RP d [ls-emit ls2 [OUnit d]]]]]]
 
-; A call to a primitive or a user function.
+; A call whose head is a symbol: a primitive, a call through a local binding
+; that holds a closure (a function parameter or a let-bound lambda), or a direct
+; call to a top-level function.
 [fn lower-call [env fns ls h args]
   [match [lower-args env fns ls args]
     [RPS regs ls1]
@@ -268,7 +344,9 @@
       [RP d ls2]
       [if [eir-prim? h]
         [RP d [ls-emit ls2 [OPrim d h regs]]]
-        [RP d [ls-emit ls2 [OCall d [fn-index fns h] regs]]]]]]]
+        [if [>= [lenv-lookup env h] 0]
+          [RP d [ls-emit ls2 [OCallV d [lenv-lookup env h] regs]]]
+          [RP d [ls-emit ls2 [OCall d [fn-index fns h] regs]]]]]]]]
 
 [fn lower-args [env fns ls items]
   [loop [k 0 ls ls acc #[]]
@@ -467,18 +545,22 @@
 
 ; ── Function & program lowering ──────────────────────────────────────────────
 
-[fn lower-fn [fns items]
+[fn lower-fn [fns items lifted base]
   [match [nth items 1] [FSym name _ _]
     [match [nth items 2] [FList params _]
-      [lower-fn-body fns name params [eir-vec-rest items 3]]
-      _ [Func name 0 0 #[]]]
-    _ [Func "?" 0 0 #[]]]]
+      [lower-fn-body-env name [params-env params] [len params]
+        [eir-vec-rest items 3] fns lifted base]
+      _ [FNR [Func name 0 0 #[]] lifted]]
+    _ [FNR [Func "?" 0 0 #[]] lifted]]]
 
-[fn lower-fn-body [fns name params body]
-  [match [lower-seq [params-env params] fns [ls-init [len params]] body]
+; Lower a function body under `env` with `nparams` parameters, threading the
+; lifted-closure accumulator. Returns the Func plus the (possibly extended)
+; accumulator, since lowering the body may lift nested lambdas.
+[fn lower-fn-body-env [name env nparams body fns lifted base]
+  [match [lower-seq env fns [ls-init nparams lifted base] body]
     [RP rreg ls]
     [match [ls-finish ls [TRet rreg]]
-      ls2 [Func name [len params] [ls-nregs ls2] [ls-blocks ls2]]]]]
+      ls2 [FNR [Func name nparams [ls-nregs ls2] [ls-blocks ls2]] [ls-lifted ls2]]]]]
 
 [fn params-env [params]
   [loop [k 0 acc #[]]
@@ -487,15 +569,21 @@
         [FSym pn _ _] [recur [+ k 1] [conj acc [VB pn k]]]
         _ [recur [+ k 1] acc]]]]]
 
+; Top-level functions occupy indices 0..base-1 (in definition order); lifted
+; closures are appended after, so a closure's index is base + its position in
+; the threaded `lifted` accumulator.
 [fn lower-program [forms0]
   [let forms [desugar-program forms0]]    ; lift handle clauses to synthetic fns
   [let fns [build-fntab forms]]
-  [Module
-    [loop [k 0 acc #[]]
-      [if [>= k [len forms]] acc
-        [match [lower-fn-def? [nth forms k]]
-          :no [recur [+ k 1] acc]
-          items [recur [+ k 1] [conj acc [lower-fn fns items]]]]]]]]
+  [let base [len fns]]
+  [loop [k 0 lifted #[] tops #[]]
+    [if [>= k [len forms]]
+      [Module [vconcat tops lifted]]
+      [match [lower-fn-def? [nth forms k]]
+        :no [recur [+ k 1] lifted tops]
+        items
+        [match [lower-fn fns items lifted base]
+          [FNR f lifted2] [recur [+ k 1] lifted2 [conj tops f]]]]]]]
 
 ; ── Desugaring: lift handler clauses to top-level synthetic functions ────────
 ;

--- a/src/frontend/run-f2-diff.sh
+++ b/src/frontend/run-f2-diff.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# F2 (self-application) gate: run the self-hosted READER on the self-hosted VM
+# and check it parses + reprints exactly as native `loon run` does.
+#
+# For each driver in tests/f2/ (a small program that read-all's an input and
+# write-form's the result):
+#   oracle = loon run (reader.oo ++ driver)            — native reader
+#   mine   = loon run (reader+eir+lower+vm ++ wrapper), where the wrapper uses
+#            eir-run-str to lower and run (reader.oo ++ driver) text on the VM
+# Reading both source files verbatim (no string interpolation) avoids any
+# quoting hazards. Equal stdout means the lowered reader, executing on the
+# self-hosted register VM — through effects (spans/diagnostics), ADTs,
+# loop/recur, strings and keywords — behaves identically to the Rust toolchain.
+set -uo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+loon="${1:-$root/target/debug/loon}"
+reader="$root/src/frontend/reader.oo"
+lib=("$reader" "$root/src/frontend/eir.oo" "$root/src/frontend/lower.oo" "$root/src/frontend/vm.oo")
+
+pass=0; fail=0
+for driver in "$root"/src/frontend/tests/f2/*.oo; do
+  name="$(basename "$driver")"
+  orc="$(mktemp /tmp/f2-orc.XXXXXX.oo)"
+  cat "$reader" "$driver" > "$orc"
+  oracle="$("$loon" run "$orc" 2>&1)"
+  wrap="$(mktemp /tmp/f2-wrap.XXXXXX.oo)"
+  full="$(mktemp /tmp/f2-full.XXXXXX.oo)"
+  printf '[fn main [] [eir-run-str [str [IO.read-file "%s"] [IO.read-file "%s"]]]]\n' "$reader" "$driver" > "$wrap"
+  cat "${lib[@]}" "$wrap" > "$full"
+  mine="$("$loon" run "$full" 2>&1)"
+  rm -f "$orc" "$wrap" "$full"
+  if [ "$oracle" = "$mine" ]; then
+    echo "  pass  $name"; pass=$((pass+1))
+  else
+    echo "  FAIL  $name"; fail=$((fail+1))
+    echo "    oracle: $(echo "$oracle" | tr '\n' '|')"
+    echo "    mine:   $(echo "$mine" | tr '\n' '|')"
+  fi
+done
+echo "f2-diff: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ] && echo "F2 GATE: PASS" || { echo "F2 GATE: FAIL"; exit 1; }

--- a/src/frontend/tests/eir/adt-list.oo
+++ b/src/frontend/tests/eir/adt-list.oo
@@ -1,0 +1,13 @@
+[type Lst [Cons Int Lst] [Nil]]
+[fn total [xs]
+  [match xs
+    [Cons h t] [+ h [total t]]
+    [Nil] 0]]
+[fn nelems [xs]
+  [match xs
+    [Cons h t] [+ 1 [nelems t]]
+    [Nil] 0]]
+[fn main []
+  [let xs [Cons 10 [Cons 20 [Cons 30 [Cons 40 [Nil]]]]]]
+  [println [total xs]]
+  [println [nelems xs]]]

--- a/src/frontend/tests/eir/adt-opt.oo
+++ b/src/frontend/tests/eir/adt-opt.oo
@@ -1,0 +1,9 @@
+[type Opt [Some Int] [None]]
+[fn or-else [o d]
+  [match o
+    [Some n] n
+    [None] d]]
+[fn main []
+  [println [or-else [Some 99] 0]]
+  [println [or-else [None] 7]]
+  [println [Some 5]]]

--- a/src/frontend/tests/eir/closures.oo
+++ b/src/frontend/tests/eir/closures.oo
@@ -1,0 +1,12 @@
+[fn vmap [f xs]
+  [loop [k 0 acc #[]]
+    [if [>= k [len xs]] acc [recur [+ k 1] [conj acc [f [nth xs k]]]]]]]
+[fn vfilter [p xs]
+  [loop [k 0 acc #[]]
+    [if [>= k [len xs]] acc
+      [recur [+ k 1] [if [p [nth xs k]] [conj acc [nth xs k]] acc]]]]]
+[fn adder [n] [fn [x] [+ x n]]]
+[fn main []
+  [println [join "," [vmap [fn [x] [* x 10]] #[1 2 3]]]]
+  [println [join "," [vfilter [fn [x] [> x 2]] #[1 2 3 4 5]]]]
+  [println [[adder 100] 23]]]

--- a/src/frontend/tests/eir/keywords.oo
+++ b/src/frontend/tests/eir/keywords.oo
@@ -1,0 +1,11 @@
+[fn kind-name [k]
+  [match k
+    :list "list"
+    :vec "vector"
+    :set "set"
+    _ "other"]]
+[fn main []
+  [println [kind-name :vec]]
+  [println [kind-name :set]]
+  [println [kind-name :map]]
+  [println [if [= :a :a] "eq" "neq"]]]

--- a/src/frontend/tests/eir/loop-reverse.oo
+++ b/src/frontend/tests/eir/loop-reverse.oo
@@ -1,0 +1,13 @@
+[type Lst [Cons Int Lst] [Nil]]
+[fn rev [xs]
+  [loop [cur xs acc [Nil]]
+    [match cur
+      [Cons h t] [recur t [Cons h acc]]
+      [Nil] acc]]]
+[fn show [xs]
+  [loop [cur xs out #[]]
+    [match cur
+      [Cons h t] [recur t [conj out h]]
+      [Nil] [join "," out]]]]
+[fn main []
+  [println [show [rev [Cons 1 [Cons 2 [Cons 3 [Nil]]]]]]]]

--- a/src/frontend/tests/eir/loop-sum.oo
+++ b/src/frontend/tests/eir/loop-sum.oo
@@ -1,0 +1,8 @@
+[fn range-sum [n]
+  [loop [k 0 acc 0]
+    [if [>= k n]
+      acc
+      [recur [+ k 1] [+ acc k]]]]]
+[fn main []
+  [println [range-sum 10]]
+  [println [range-sum 100]]]

--- a/src/frontend/tests/eir/sum.oo
+++ b/src/frontend/tests/eir/sum.oo
@@ -1,5 +1,5 @@
-[fn sum [v i acc]
+[fn addv [v i acc]
   [if [>= i [len v]]
     acc
-    [sum v [+ i 1] [+ acc [nth v i]]]]]
-[fn main [] [println [sum #[1 2 3 4 5 6 7 8 9 10] 0 0]]]
+    [addv v [+ i 1] [+ acc [nth v i]]]]]
+[fn main [] [println [addv #[1 2 3 4 5 6 7 8 9 10] 0 0]]]

--- a/src/frontend/tests/eir_inline.oo
+++ b/src/frontend/tests/eir_inline.oo
@@ -74,4 +74,11 @@
     "[fn sv [v] [loop [k 0 acc 0] [if [>= k [len v]] acc [recur [+ k 1] [+ acc [nth v k]]]]]] [fn main [] [sv #[3 4 5 6]]]"
     "18"]
 
+  ; ── keywords ──
+  [evals "kw literal"  "[fn main [] :hello]" ":hello"]
+  [evals "kw eq"       "[fn main [] [if [= :a :a] 1 0]]" "1"]
+  [evals "kw neq"      "[fn main [] [if [= :a :b] 1 0]]" "0"]
+  [evals "kw match"    "[fn f [k] [match k :vec \"V\" :set \"S\" _ \"?\"]] [fn main [] [f :set]]" "S"]
+  [evals "kw in vec"   "[fn main [] [join \",\" #[:a :b :c]]]" ":a,:b,:c"]
+
   [println "done"]]

--- a/src/frontend/tests/eir_inline.oo
+++ b/src/frontend/tests/eir_inline.oo
@@ -65,4 +65,13 @@
   [evals "ctor in body"
     "[fn box [n] [Some n]] [fn main [] [match [box 5] [Some x] [* x x] [None] 0]]" "25"]
 
+  ; ── loop / recur ──
+  [evals "loop count"  "[fn main [] [loop [k 0 acc 0] [if [>= k 5] acc [recur [+ k 1] [+ acc k]]]]]" "10"]
+  [evals "loop fact"   "[fn main [] [loop [n 5 acc 1] [if [= n 0] acc [recur [- n 1] [* acc n]]]]]" "120"]
+  [evals "loop build"  "[fn main [] [loop [k 0 acc #[]] [if [>= k 3] [len acc] [recur [+ k 1] [conj acc k]]]]]" "3"]
+  [evals "loop swap"   "[fn main [] [loop [a 1 b 10 k 0] [if [>= k 3] [+ a b] [recur b a [+ k 1]]]]]" "11"]
+  [evals "loop in fn"
+    "[fn sv [v] [loop [k 0 acc 0] [if [>= k [len v]] acc [recur [+ k 1] [+ acc [nth v k]]]]]] [fn main [] [sv #[3 4 5 6]]]"
+    "18"]
+
   [println "done"]]

--- a/src/frontend/tests/eir_inline.oo
+++ b/src/frontend/tests/eir_inline.oo
@@ -88,4 +88,13 @@
   [evals "perform deep"
     "[effect S [span]] [fn inner [] [S.span]] [fn outer [] [inner]] [fn main [] [handle [outer] [S.span] [resume 7]]]" "7"]
 
+  ; ── closures ──
+  [evals "capture"    "[fn main [] [let n 10] [let f [fn [x] [+ x n]]] [f 5]]" "15"]
+  [evals "higher-ord" "[fn ap2 [f x] [f [f x]]] [fn main [] [ap2 [fn [y] [* y 3]] 2]]" "18"]
+  [evals "curry"      "[fn main [] [let mk [fn [a] [fn [b] [+ a b]]]] [[mk 100] 7]]" "107"]
+  [evals "identity"   "[fn main [] [let id [fn [x] x]] [id 42]]" "42"]
+  [evals "map-like"
+    "[fn vmap [f xs] [loop [k 0 acc #[]] [if [>= k [len xs]] acc [recur [+ k 1] [conj acc [f [nth xs k]]]]]]] [fn main [] [join \",\" [vmap [fn [x] [* x x]] #[1 2 3 4]]]]"
+    "1,4,9,16"]
+
   [println "done"]]

--- a/src/frontend/tests/eir_inline.oo
+++ b/src/frontend/tests/eir_inline.oo
@@ -81,4 +81,11 @@
   [evals "kw match"    "[fn f [k] [match k :vec \"V\" :set \"S\" _ \"?\"]] [fn main [] [f :set]]" "S"]
   [evals "kw in vec"   "[fn main [] [join \",\" #[:a :b :c]]]" ":a,:b,:c"]
 
+  ; ── effects / handle (tail-resumptive) ──
+  [evals "resume"      "[effect E [op]] [fn u [] [E.op]] [fn main [] [handle [u] [E.op] [resume 42]]]" "42"]
+  [evals "resume arg"  "[effect E [dbl]] [fn u [x] [E.dbl x]] [fn main [] [handle [u 21] [E.dbl n] [resume [* n 2]]]]" "42"]
+  [evals "two ops"     "[effect E [a b]] [fn u [] [+ [E.a] [E.b]]] [fn main [] [handle [u] [E.a] [resume 10] [E.b] [resume 5]]]" "15"]
+  [evals "perform deep"
+    "[effect S [span]] [fn inner [] [S.span]] [fn outer [] [inner]] [fn main [] [handle [outer] [S.span] [resume 7]]]" "7"]
+
   [println "done"]]

--- a/src/frontend/tests/eir_inline.oo
+++ b/src/frontend/tests/eir_inline.oo
@@ -53,4 +53,16 @@
     "[fn sum [v i acc] [if [>= i [len v]] acc [sum v [+ i 1] [+ acc [nth v i]]]]] [fn main [] [sum #[1 2 3 4 5] 0 0]]"
     "15"]
 
+  ; ── ADT values + constructor patterns ──
+  [evals "Some unwrap"  "[fn f [o] [match o [Some n] n [None] -1]] [fn main [] [f [Some 42]]]" "42"]
+  [evals "None arm"     "[fn f [o] [match o [Some n] n [None] -1]] [fn main [] [f [None]]]" "-1"]
+  [evals "ctor display" "[fn main [] [Some 7]]" "[Some 7]"]
+  [evals "nullary disp" "[fn main [] [None]]" "[None]"]
+  [evals "two fields"   "[fn fst [p] [match p [Pair a b] a]] [fn main [] [fst [Pair 11 22]]]" "11"]
+  [evals "list sum"
+    "[fn s [xs] [match xs [Cons h t] [+ h [s t]] [Nil] 0]] [fn main [] [s [Cons 1 [Cons 2 [Cons 3 [Nil]]]]]]"
+    "6"]
+  [evals "ctor in body"
+    "[fn box [n] [Some n]] [fn main [] [match [box 5] [Some x] [* x x] [None] 0]]" "25"]
+
   [println "done"]]

--- a/src/frontend/tests/f2/dump.oo
+++ b/src/frontend/tests/f2/dump.oo
@@ -1,0 +1,6 @@
+[fn dump [fs]
+  [loop [k 0]
+    [if [>= k [len fs]] 0
+      [do [println [write-form [nth fs k]]] [recur [+ k 1]]]]]]
+[fn main []
+  [dump [read-all "[fn add [a b] [+ a b]] [let xs #[1 2 3] k :tag]"]]]

--- a/src/frontend/tests/f2/simple.oo
+++ b/src/frontend/tests/f2/simple.oo
@@ -1,0 +1,1 @@
+[fn main [] [println [write-form [nth [read-all "[+ 1 [foo :bar 42]]"] 0]]]]

--- a/src/frontend/tests/f2/strings.oo
+++ b/src/frontend/tests/f2/strings.oo
@@ -1,0 +1,1 @@
+[fn main [] [println [write-form [nth [read-all "[concat \"hi there\" \"!\"]"] 0]]]]

--- a/src/frontend/vm.oo
+++ b/src/frontend/vm.oo
@@ -20,6 +20,7 @@
   [VKw String]         ; keyword (:name, stored without colon)
   [VVec Vec]           ; vector of Vals
   [VAdt String Vec]    ; constructor value: tag + fields
+  [VClosure i64 Vec]   ; closure: function index + captured values
   [VUnit]]
 
 [fn vint [v] [match v [VInt i] i _ 0]]
@@ -39,6 +40,7 @@
     [VVec xs]  [str "#[" [join " " [map-display-vec xs]] "]"]
     [VAdt t fs] [if [= [len fs] 0] [str "[" t "]"]
                   [str "[" t " " [join " " [map-display-vec fs]] "]"]]
+    [VClosure _ _] "#<closure>"
     [VUnit]    "()"]]
 
 [fn map-display-vec [xs]
@@ -204,7 +206,19 @@
     [OCall d fi args] [ER [vset regs d [exec-func funcs [nth funcs fi] [gather regs args] handlers]] handlers]
     [OPerform d nm args] [ER [vset regs d [perform funcs handlers nm [gather regs args]]] handlers]
     [OHandlePush frame] [ER regs [conj handlers frame]]
-    [OHandlePop] [ER regs [slice handlers 0 [- [len handlers] 1]]]]]
+    [OHandlePop] [ER regs [slice handlers 0 [- [len handlers] 1]]]
+    [OClosure d fi caps] [ER [vset regs d [VClosure fi [gather regs caps]]] handlers]
+    [OCallV d fr args] [ER [vset regs d [call-closure funcs [nth regs fr] [gather regs args] handlers]] handlers]]]
+
+; Call a closure: prepend its captured values to the arguments and invoke its
+; function (the lifted function's leading parameters are the captures).
+[fn call-closure [funcs cval args handlers]
+  [match cval
+    [VClosure fi caps] [exec-func funcs [nth funcs fi] [vapp caps args] handlers]
+    _ [VUnit]]]
+
+[fn vapp [a b]
+  [loop [k 0 acc a] [if [>= k [len b]] acc [recur [+ k 1] [conj acc [nth b k]]]]]]
 
 ; Perform an effect operation: find the innermost handler for it and call its
 ; (synthetic) handler function with the operation arguments. Tail-resumptive —

--- a/src/frontend/vm.oo
+++ b/src/frontend/vm.oo
@@ -17,6 +17,7 @@
   [VFloat String]      ; kept as lexeme (no float arithmetic in this slice)
   [VStr String]
   [VBool Bool]
+  [VKw String]         ; keyword (:name, stored without colon)
   [VVec Vec]           ; vector of Vals
   [VAdt String Vec]    ; constructor value: tag + fields
   [VUnit]]
@@ -34,6 +35,7 @@
     [VFloat s] s
     [VStr s]   s
     [VBool b]  [if b "true" "false"]
+    [VKw n]    [str ":" n]
     [VVec xs]  [str "#[" [join " " [map-display-vec xs]] "]"]
     [VAdt t fs] [if [= [len fs] 0] [str "[" t "]"]
                   [str "[" t " " [join " " [map-display-vec fs]] "]"]]
@@ -138,6 +140,7 @@
     [VInt a]  [match y [VInt b] [= a b] _ false]
     [VBool a] [match y [VBool b] [= a b] _ false]
     [VStr a]  [match y [VStr b] [streq a b] _ false]
+    [VKw a]   [match y [VKw b] [streq a b] _ false]
     [VAdt at af] [match y [VAdt bt bf] [if [streq at bt] [vals-eq af bf] false] _ false]
     [VUnit]   [match y [VUnit] true _ false]
     _ false]]
@@ -180,6 +183,7 @@
     [OFloat d lex] [vset regs d [VFloat lex]]
     [OStr d v]     [vset regs d [VStr v]]
     [OBool d b]    [vset regs d [VBool b]]
+    [OKw d n]      [vset regs d [VKw n]]
     [OUnit d]      [vset regs d [VUnit]]
     [OMove d s]    [vset regs d [nth regs s]]
     [OVec d args]  [vset regs d [VVec [gather regs args]]]

--- a/src/frontend/vm.oo
+++ b/src/frontend/vm.oo
@@ -153,45 +153,79 @@
     false]]
 
 ; ── Execution ─────────────────────────────────────────────────────────────────
+;
+; A dynamic handler stack is threaded through execution (exec-func ->
+; run-blocks -> exec-ops) and along the executed block path, so installed
+; handlers are visible to perform sites in the body and in any function it
+; calls. exec-ops returns both the register file and the (possibly updated)
+; handler stack via ER, since OHandlePush/OHandlePop mutate it.
+[type ER [ER Vec Vec]]    ; registers, handler stack
 
-[fn exec-func [funcs func args]
+[fn exec-func [funcs func args handlers]
   [match func [Func _ _ nr blocks]
-    [run-blocks funcs blocks [make-regs nr args] 0]]]
+    [run-blocks funcs blocks [make-regs nr args] handlers 0]]]
 
-[fn run-blocks [funcs blocks regs id]
+[fn run-blocks [funcs blocks regs handlers id]
   [match [eir-find-block blocks id]
     :none [VUnit]
-    blk [run-block funcs blocks blk regs]]]
+    blk [run-block funcs blocks blk regs handlers]]]
 
-[fn run-block [funcs blocks blk regs]
+[fn run-block [funcs blocks blk regs handlers]
   [match blk [Block _ ops term]
-    [run-term funcs blocks term [exec-ops funcs regs ops]]]]
+    [match [exec-ops funcs regs handlers ops]
+      [ER regs2 handlers2] [run-term funcs blocks term regs2 handlers2]]]]
 
-[fn run-term [funcs blocks term regs]
+[fn run-term [funcs blocks term regs handlers]
   [match term
     [TRet r] [nth regs r]
-    [TBr b] [run-blocks funcs blocks regs b]
-    [TBrIf c a b] [run-blocks funcs blocks regs [if [truthy [nth regs c]] a b]]]]
+    [TBr b] [run-blocks funcs blocks regs handlers b]
+    [TBrIf c a b] [run-blocks funcs blocks regs handlers [if [truthy [nth regs c]] a b]]]]
 
-[fn exec-ops [funcs regs ops]
-  [loop [k 0 regs regs]
-    [if [>= k [len ops]] regs [recur [+ k 1] [exec-op funcs regs [nth ops k]]]]]]
+[fn exec-ops [funcs regs handlers ops]
+  [loop [k 0 regs regs handlers handlers]
+    [if [>= k [len ops]] [ER regs handlers]
+      [match [exec-op funcs regs handlers [nth ops k]]
+        [ER r2 h2] [recur [+ k 1] r2 h2]]]]]
 
-[fn exec-op [funcs regs op]
+[fn exec-op [funcs regs handlers op]
   [match op
-    [OInt d lex]   [vset regs d [VInt [parse-int lex]]]
-    [OFloat d lex] [vset regs d [VFloat lex]]
-    [OStr d v]     [vset regs d [VStr v]]
-    [OBool d b]    [vset regs d [VBool b]]
-    [OKw d n]      [vset regs d [VKw n]]
-    [OUnit d]      [vset regs d [VUnit]]
-    [OMove d s]    [vset regs d [nth regs s]]
-    [OVec d args]  [vset regs d [VVec [gather regs args]]]
-    [OAdt d ctor args] [vset regs d [VAdt ctor [gather regs args]]]
-    [OTag d s]     [vset regs d [VStr [adt-tag [nth regs s]]]]
-    [OField d s ix] [vset regs d [adt-field [nth regs s] ix]]
-    [OPrim d nm args] [vset regs d [apply-prim nm [gather regs args]]]
-    [OCall d fi args] [vset regs d [exec-func funcs [nth funcs fi] [gather regs args]]]]]
+    [OInt d lex]   [ER [vset regs d [VInt [parse-int lex]]] handlers]
+    [OFloat d lex] [ER [vset regs d [VFloat lex]] handlers]
+    [OStr d v]     [ER [vset regs d [VStr v]] handlers]
+    [OBool d b]    [ER [vset regs d [VBool b]] handlers]
+    [OKw d n]      [ER [vset regs d [VKw n]] handlers]
+    [OUnit d]      [ER [vset regs d [VUnit]] handlers]
+    [OMove d s]    [ER [vset regs d [nth regs s]] handlers]
+    [OVec d args]  [ER [vset regs d [VVec [gather regs args]]] handlers]
+    [OAdt d ctor args] [ER [vset regs d [VAdt ctor [gather regs args]]] handlers]
+    [OTag d s]     [ER [vset regs d [VStr [adt-tag [nth regs s]]]] handlers]
+    [OField d s ix] [ER [vset regs d [adt-field [nth regs s] ix]] handlers]
+    [OPrim d nm args] [ER [vset regs d [apply-prim nm [gather regs args]]] handlers]
+    [OCall d fi args] [ER [vset regs d [exec-func funcs [nth funcs fi] [gather regs args] handlers]] handlers]
+    [OPerform d nm args] [ER [vset regs d [perform funcs handlers nm [gather regs args]]] handlers]
+    [OHandlePush frame] [ER regs [conj handlers frame]]
+    [OHandlePop] [ER regs [slice handlers 0 [- [len handlers] 1]]]]]
+
+; Perform an effect operation: find the innermost handler for it and call its
+; (synthetic) handler function with the operation arguments. Tail-resumptive —
+; the handler's return value IS the perform's result (resume is the identity).
+[fn perform [funcs handlers nm vals]
+  [let fi [find-handler handlers nm]]
+  [if [< fi 0]
+    [VUnit]                                       ; unhandled effect: unit
+    [exec-func funcs [nth funcs fi] vals handlers]]]
+
+[fn find-handler [handlers nm]
+  [loop [fk [- [len handlers] 1]]
+    [if [< fk 0] -1
+      [if [>= [find-in-frame [nth handlers fk] nm] 0]
+        [find-in-frame [nth handlers fk] nm]
+        [recur [- fk 1]]]]]]
+
+[fn find-in-frame [frame nm]
+  [loop [k 0]
+    [if [>= k [len frame]] -1
+      [match [nth frame k] [HE op fi] [if [streq op nm] fi [recur [+ k 1]]]]]]]
 
 ; ── Entry points ──────────────────────────────────────────────────────────────
 
@@ -202,7 +236,7 @@
 
 [fn run-module [m]
   [match m [Module funcs]
-    [match [find-main funcs] :none [VUnit] mi [exec-func funcs [nth funcs mi] #[]]]]]
+    [match [find-main funcs] :none [VUnit] mi [exec-func funcs [nth funcs mi] #[] #[]]]]]
 
 ; Lower a program (vector of Forms) to EIR and run it; returns main's value.
 [fn eir-run [forms] [run-module [lower-program forms]]]

--- a/src/frontend/vm.oo
+++ b/src/frontend/vm.oo
@@ -18,11 +18,14 @@
   [VStr String]
   [VBool Bool]
   [VVec Vec]           ; vector of Vals
+  [VAdt String Vec]    ; constructor value: tag + fields
   [VUnit]]
 
 [fn vint [v] [match v [VInt i] i _ 0]]
 [fn vstr [v] [match v [VStr s] s _ [display v]]]
 [fn vvec [v] [match v [VVec xs] xs _ #[]]]
+[fn adt-tag [v] [match v [VAdt t _] t _ ""]]
+[fn adt-field [v i] [match v [VAdt _ fs] [nth fs i] _ [VUnit]]]
 [fn truthy [v] [match v [VBool b] b [VUnit] false _ true]]
 
 [fn display [v]
@@ -32,6 +35,8 @@
     [VStr s]   s
     [VBool b]  [if b "true" "false"]
     [VVec xs]  [str "#[" [join " " [map-display-vec xs]] "]"]
+    [VAdt t fs] [if [= [len fs] 0] [str "[" t "]"]
+                  [str "[" t " " [join " " [map-display-vec fs]] "]"]]
     [VUnit]    "()"]]
 
 [fn map-display-vec [xs]
@@ -133,8 +138,16 @@
     [VInt a]  [match y [VInt b] [= a b] _ false]
     [VBool a] [match y [VBool b] [= a b] _ false]
     [VStr a]  [match y [VStr b] [streq a b] _ false]
+    [VAdt at af] [match y [VAdt bt bf] [if [streq at bt] [vals-eq af bf] false] _ false]
     [VUnit]   [match y [VUnit] true _ false]
     _ false]]
+
+[fn vals-eq [as bs]
+  [if [= [len as] [len bs]]
+    [loop [k 0]
+      [if [>= k [len as]] true
+        [if [val-eq [nth as k] [nth bs k]] [recur [+ k 1]] false]]]
+    false]]
 
 ; ── Execution ─────────────────────────────────────────────────────────────────
 
@@ -170,6 +183,9 @@
     [OUnit d]      [vset regs d [VUnit]]
     [OMove d s]    [vset regs d [nth regs s]]
     [OVec d args]  [vset regs d [VVec [gather regs args]]]
+    [OAdt d ctor args] [vset regs d [VAdt ctor [gather regs args]]]
+    [OTag d s]     [vset regs d [VStr [adt-tag [nth regs s]]]]
+    [OField d s ix] [vset regs d [adt-field [nth regs s] ix]]
     [OPrim d nm args] [vset regs d [apply-prim nm [gather regs args]]]
     [OCall d fi args] [vset regs d [exec-func funcs [nth funcs fi] [gather regs args]]]]]
 


### PR DESCRIPTION
This PR extends the EIR lowering and VM to support algebraic data types (ADTs), tail-recursive loops, keyword literals, and algebraic effects—completing the feature set needed for self-hosted compilation.

## Summary

The self-hosted reader, type checker, and code generator require several language features that were previously missing from the EIR intermediate representation and lowering pipeline. This change adds:

1. **Algebraic Data Types (ADTs)**: Constructor application, pattern matching on constructors with field extraction, and ADT value representation in the VM
2. **Tail-Recursive Loops**: `loop`/`recur` forms that compile to efficient block-based iteration with a handler context threaded through the environment
3. **Keyword Literals**: `:name` syntax support in expressions and patterns
4. **Algebraic Effects**: `handle`/`perform` for effect handling, with desugaring that lifts handler clauses to synthetic functions and a dynamic handler stack in the VM

## Key Changes

**EIR & Lowering (`src/frontend/eir.oo`, `src/frontend/lower.oo`)**
- Added `OKw`, `OAdt`, `OTag`, `OField`, `OPerform`, `OHandlePush`, `OHandlePop` operations
- Extended environment type `Env` to hold both variable bindings (`VB`) and loop contexts (`LCtx`), allowing `recur` to find its enclosing loop
- Implemented `lower-loop` and `lower-recur` to compile tail-recursive iteration into block jumps with register moves
- Added constructor pattern matching (`lower-arm-ctor`) with field extraction via `OField`
- Implemented `lower-handle` and `lower-perform` for effect operations
- Added desugaring pass (`desugar-program`) that lifts handler clauses to top-level synthetic functions, making handlers callable by index
- Added `lower-form` dispatcher to route special forms (`if`, `match`, `do`, `loop`, `recur`, `let`, `handle`, `resume`) and constructor application

**VM (`src/frontend/vm.oo`)**
- Added `VKw` and `VAdt` value types
- Threaded a dynamic handler stack through execution (`exec-func`, `run-blocks`, `exec-ops`)
- Implemented `perform` to find and call the innermost handler for an effect operation (tail-resumptive)
- Added `OTag` and `OField` operations to extract constructor metadata and fields at runtime

**Tests & Validation**
- Added comprehensive inline tests for ADTs, loop/recur, keywords, and effects in `eir_inline.oo`
- Added standalone test files: `adt-opt.oo`, `adt-list.oo`, `loop-sum.oo`, `loop-reverse.oo`, `keywords.oo`
- Added F2 (self-application) gate script (`run-f2-diff.sh`) to validate the self-hosted reader executing on the lowered VM against the native reader

## Notable Implementation Details

- **Environment heterogeneity**: The `Env` type unifies variable bindings and loop contexts so `match` can discriminate them reliably within a single type, avoiding silent mismatches when heterogeneous collections are pattern-matched.
- **Desugaring for effects**: Handler clauses are lifted to synthetic functions (`$h0`, `$h1`, etc.) at the top level, with `resume` stripped to the identity. This keeps lowering oblivious to handler scoping and makes handlers ordinary functions callable by index.
- **Loop context threading**: Loop metadata (header block, result register, join block, loop-variable registers) rides in the environment so `recur` can find the innermost enclosing loop without explicit parameters.
- **Tail-resumptive handlers**: Perform sites call handler functions directly; the handler's return value is the perform's result, making handlers naturally tail-resumptive without explicit `resume` machinery.

https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus