### PR TITLE
Elegance: make = structural (fix the string-equality wart)

### DIFF
--- a/crates/loon-lang/src/eir/vm.rs
+++ b/crates/loon-lang/src/eir/vm.rs
@@ -217,6 +217,55 @@ impl Vm {
         }
     }
 
+    /// Structural value equality (the semantics of `=` / `!=`).
+    ///
+    /// Immediates and identical pointers compare by bits (the fast path); two
+    /// distinct heap objects are compared by content, recursively. This matches
+    /// the legacy tree-walking interpreter (whose `Value` derives a structural
+    /// `PartialEq`) — without it `=` on strings is pointer identity, so e.g.
+    /// `[= "ab" [str "a" "b"]]` would be false. Loon values are immutable and
+    /// acyclic, so the recursion terminates.
+    fn val_eq(&self, a: Val, b: Val) -> bool {
+        if a == b {
+            return true;
+        }
+        match (self.get_obj(a), self.get_obj(b)) {
+            (Some(oa), Some(ob)) => self.obj_eq(oa, ob),
+            _ => false,
+        }
+    }
+
+    fn obj_eq(&self, a: &Obj, b: &Obj) -> bool {
+        match (a, b) {
+            (Obj::Str(x), Obj::Str(y)) => x == y,
+            (Obj::Vec(x), Obj::Vec(y)) => {
+                x.len() == y.len() && x.iter().zip(y.iter()).all(|(p, q)| self.val_eq(*p, *q))
+            }
+            (Obj::Tuple(x), Obj::Tuple(y)) => {
+                x.len() == y.len() && x.iter().zip(y.iter()).all(|(p, q)| self.val_eq(*p, *q))
+            }
+            (Obj::Adt(tx, fx), Obj::Adt(ty, fy)) => {
+                tx == ty
+                    && fx.len() == fy.len()
+                    && fx.iter().zip(fy.iter()).all(|(p, q)| self.val_eq(*p, *q))
+            }
+            // Sets and maps are unordered: every entry of one must have a
+            // structurally equal counterpart in the other.
+            (Obj::Set(x), Obj::Set(y)) => {
+                x.len() == y.len() && x.iter().all(|p| y.iter().any(|q| self.val_eq(*p, *q)))
+            }
+            (Obj::Map(x), Obj::Map(y)) => {
+                x.len() == y.len()
+                    && x.iter().all(|(k, v)| {
+                        y.iter()
+                            .any(|(k2, v2)| self.val_eq(*k, *k2) && self.val_eq(*v, *v2))
+                    })
+            }
+            // Closures compare by identity only (handled by the fast path).
+            _ => false,
+        }
+    }
+
     fn resolve_string(&mut self, sid: StringId) -> Val {
         if let Some(&idx) = self.string_cache.get(&sid) {
             return Val::ptr(idx);
@@ -784,8 +833,8 @@ impl Vm {
                     Val::UNIT
                 }
             }
-            BinOp::Eq => Val::bool(a == b),
-            BinOp::Ne => Val::bool(a != b),
+            BinOp::Eq => Val::bool(self.val_eq(a, b)),
+            BinOp::Ne => Val::bool(!self.val_eq(a, b)),
             BinOp::Lt => {
                 if a.is_int() && b.is_int() {
                     Val::bool(a.as_int() < b.as_int())
@@ -1969,6 +2018,25 @@ mod tests {
         assert!(run("[> 3 2]").as_bool());
         assert!(!run("[< 3 2]").as_bool());
         assert!(run("[= 1 1]").as_bool());
+    }
+
+    #[test]
+    fn vm_structural_equality() {
+        // Strings compare by content, not by heap identity: two independently
+        // computed strings are equal (this used to be false — pointer equality).
+        assert!(run(r#"[= "ab" [str "a" "b"]]"#).as_bool());
+        assert!(run(r#"[= [str "a" "b"] [str "a" "b"]]"#).as_bool());
+        assert!(!run(r#"[= "ab" "ba"]"#).as_bool());
+        // Aggregates are structural and recursive.
+        assert!(run("[= #[1 2 3] #[1 2 3]]").as_bool());
+        assert!(!run("[= #[1 2] #[1 2 3]]").as_bool());
+        assert!(run("[= #[#[1] #[2]] #[#[1] #[2]]]").as_bool());
+        assert!(run("[= {:a 1 :b 2} {:b 2 :a 1}]").as_bool());
+        assert!(!run("[= {:a 1} {:a 2}]").as_bool());
+        assert!(run("[type T [C Int]] [= [C 1] [C 1]]").as_bool());
+        assert!(!run("[type T [C Int]] [= [C 1] [C 2]]").as_bool());
+        // `!=` is the negation.
+        assert!(run(r#"[!= "ab" [str "a" "c"]]"#).as_bool());
     }
 
     #[test]

--- a/docs/elegance-notes.md
+++ b/docs/elegance-notes.md
@@ -9,12 +9,12 @@ Legend: **break?** = backward-incompatible · **effort** S/M/L.
 
 ## A. Language warts (worth breaking to fix)
 
-1. **`=` is heap identity for strings.** The reader has to build string equality
-   from `len` + `index-of` (`streq`), and char comparison goes through
-   `index-of` membership — never `=`. This is the single most surprising wart:
-   `[= "ab" "ab"]` is `false`. **Fix:** make `=` structural for strings (and
-   ideally collections), with identity available as a separate `same?` if
-   needed. _break? yes (subtle) · effort M_
+1. **✅ FIXED — `=` is now structural.** Previously `=` in the EIR VM was heap
+   identity for strings and aggregates, so `[= "ab" [str "a" "b"]]` was `false`
+   and the reader had to build string equality from `len`+`index-of` (`streq`).
+   The VM now compares strings, vectors, tuples, ADTs, sets, and maps by content
+   (recursively), matching the legacy interpreter — see `val_eq` in `eir/vm.rs`.
+   Follow-up: the `streq` workaround in `reader.oo` can now be replaced with `=`.
 
 2. **`{…}` string interpolation collides with set/map literals.** You cannot
    write a literal `{` in a string: `"#{IO}"` becomes `#IO`, and `"#{}"` errors


### PR DESCRIPTION
Fixes the single most-cited wart in `docs/elegance-notes.md` (#1) — one we kept tripping over while self-hosting.

## The problem
The default execution path (`eir::vm`, what `loon run` uses) compared values by their NaN-boxed bits, so `=` on heap objects was **pointer identity**:

```
[= "ab" [str "a" "b"]]   ; => false  (!)
[= [str "a" "b"] [str "a" "b"]]  ; => false
```

Only interned-equal string *literals* compared equal, which is why `match` on string literals appeared to work while real string comparison didn't. The self-hosted reader had to build its own `streq` from `len` + `index-of` everywhere. It also **diverged from the legacy tree-walking interpreter**, whose `Value` derives a structural `PartialEq` (there, `[= "ab" [str "a" "b"]]` is already `true`).

## The fix
`exec_binop` now routes `=`/`!=` through a structural `val_eq`:
- immediates / identical pointers → compare by bits (fast path),
- otherwise deref both heap objects and compare by **content, recursively**: strings by bytes; vectors/tuples/ADTs elementwise; sets/maps by unordered entry matching.

Loon values are immutable and acyclic, so the recursion terminates. `match`-on-literal (which lowers to `BinOp::Eq`) keeps working — structural equality is a superset of the old interned-literal behavior.

```
[= "ab" [str "a" "b"]]      ; => true
[= #[1 2 3] #[1 2 3]]       ; => true
[= {:a 1 :b 2} {:b 2 :a 1}] ; => true
[type Opt [Some Int] [None]] [= [Some 1] [Some 1]]  ; => true
```

This also makes the EIR VM and the legacy interpreter **agree** on `=`.

## Tests
- New `vm_structural_equality` covering strings (literal vs computed), nested vectors, maps, ADTs, and `!=`.
- Full `loon-lang` + `loon-cli` suites pass (468 tests).
- All self-hosted differential/self-application gates still green (`eir`, `f2`, `check`, …).

## Follow-ups (not in this PR)
- The `streq` workaround in `reader.oo` can now be replaced with `=`.
- The experimental `--native` (cranelift) and WASM codegen paths still compare strings by pointer; they'd need a runtime equality call to match.
- Other logged warts remain: `{`-in-strings (#2), builtin-shadowing (#4b), cross-type `match` leak (#4c), unordered maps (#4d).

https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus)_