### PR TITLE
Elegance: int/float parse strings (fix string→number)

### DIFF
--- a/crates/loon-lang/src/eir/vm.rs
+++ b/crates/loon-lang/src/eir/vm.rs
@@ -1389,6 +1389,13 @@ impl Vm {
                     Ok(v)
                 } else if v.is_float() {
                     Ok(self.safe_int(v.as_float() as i64))
+                } else if let Some(s) = self.get_str(v) {
+                    // Parse a string to an integer (the builtin's declared type
+                    // is Str → Int); unparseable strings yield ().
+                    match s.trim().parse::<i64>() {
+                        Ok(n) => Ok(self.safe_int(n)),
+                        Err(_) => Ok(Val::UNIT),
+                    }
                 } else {
                     Ok(Val::UNIT)
                 }
@@ -1399,6 +1406,11 @@ impl Vm {
                     Ok(v)
                 } else if v.is_int() {
                     Ok(Val::float(v.as_int() as f64))
+                } else if let Some(s) = self.get_str(v) {
+                    match s.trim().parse::<f64>() {
+                        Ok(n) => Ok(Val::float(n)),
+                        Err(_) => Ok(Val::UNIT),
+                    }
                 } else {
                     Ok(Val::UNIT)
                 }
@@ -2018,6 +2030,20 @@ mod tests {
         assert!(run("[> 3 2]").as_bool());
         assert!(!run("[< 3 2]").as_bool());
         assert!(run("[= 1 1]").as_bool());
+    }
+
+    #[test]
+    fn vm_int_float_parse() {
+        // int/float parse strings (their declared type is Str -> Int/Float).
+        assert_eq!(run(r#"[int "42"]"#).as_int(), 42);
+        assert_eq!(run(r#"[int "-7"]"#).as_int(), -7);
+        assert_eq!(run(r#"[int " 13 "]"#).as_int(), 13);
+        assert_eq!(run(r#"[+ [int "40"] 2]"#).as_int(), 42);
+        assert!(run(r#"[int "nope"]"#).is_unit());
+        assert!((run(r#"[float "3.14"]"#).as_float() - 3.14).abs() < 1e-9);
+        // numeric conversions still work.
+        assert_eq!(run("[int 9]").as_int(), 9);
+        assert_eq!(run("[int 3.9]").as_int(), 3);
     }
 
     #[test]

--- a/docs/elegance-notes.md
+++ b/docs/elegance-notes.md
@@ -65,11 +65,12 @@ Legend: **break?** = backward-incompatible · **effort** S/M/L.
 
 ## B. Missing builtins / stdlib
 
-6. **No `string → number` parsing.** The reader deliberately keeps numeric
-   lexemes as strings, but then *everyone* downstream needs to parse them; the
-   self-hosted VM had to hand-roll `parse-int` (digit fold via `index-of`).
-   **Add:** `int`/`float`/`parse-int` (and confirm `str` covers number→string).
-   _break? no · effort S_
+6. **✅ FIXED — `string → number` parsing.** `int` and `float` are typed
+   `Str → Int`/`Str → Float` but their EIR VM impls ignored strings (returned
+   `()`); they now parse (`[int "42"]` → `42`, whitespace trimmed, unparseable
+   → `()`), keeping the int/float numeric conversions too. See `Built::Int` /
+   `Built::Float` in `eir/vm.rs`. Follow-up: the self-hosted VM's hand-rolled
+   `parse-int` can now defer to the native `int`.
 
 7. **No structural equality / `Display` story.** `str`/`println` are variadic and
    ad-hoc; there's no `Show`/`Display` trait, so the VM reimplements value


### PR DESCRIPTION
Second elegance PR — fixes wart #6 (`string → number` parsing), which we had to hand-roll a `parse-int` for while self-hosting.

## The problem
`int` and `float` are declared in the type checker as `Str → Int` / `Str → Float`, so string parsing was clearly the *intended* behavior — but the EIR VM implementations only handled numeric conversion and returned `()` for string arguments:

```
[int "42"]   ; => ()   (!), despite the type being Str -> Int
[float "3.14"] ; => ()
```

That's why the self-hosted VM had to hand-roll `parse-int` (a digit fold via `index-of`).

## The fix
`Built::Int` / `Built::Float` now parse a string argument (trimmed) with Rust's `i64`/`f64` parse, yielding `()` on failure — while keeping the existing `int`↔`float` numeric conversions. The impls now match their declared types.

```
[int "42"]        ; => 42
[int "-7"]        ; => -7
[int " 13 "]      ; => 13   (trimmed)
[int "nope"]      ; => ()
[float "3.14"]    ; => 3.14
[+ [int "40"] 2]  ; => 42   (usable in arithmetic)
[int 9] [int 3.9] ; => 9, 3 (numeric conversion still works)
```

## Tests
- New `vm_int_float_parse`.
- Full `loon-lang` + `loon-cli` suites pass (327 in loon-lang).
- Self-hosted gates (`eir`, `f2`, `check`) still green.

## Follow-up (not in this PR)
The self-hosted VM's hand-rolled `parse-int` can now defer to the native `int`.

https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus)_