### PR TITLE
Elegance batch: globally-unique ctor tags + user fns shadow builtins

### DIFF
--- a/crates/loon-lang/src/eir/lower.rs
+++ b/crates/loon-lang/src/eir/lower.rs
@@ -40,6 +40,10 @@ struct Lower<'a> {
     string_map: HashMap<String, StringId>,
     /// Known ADT constructors: name → (tag, arity).
     ctor_map: HashMap<String, (u16, u16)>,
+    /// Next constructor tag. Tags are GLOBALLY unique across all type
+    /// declarations (not reset per type), so a pattern of one type cannot match
+    /// a value of another type that happens to share a per-type ordinal.
+    next_tag: u16,
     /// Evidence in scope: "Effect.op" → Reg holding handler fn ptr.
     evidence_scope: HashMap<String, Reg>,
     /// Function name → FuncId (for direct calls).
@@ -64,6 +68,7 @@ impl<'a> Lower<'a> {
             scopes: vec![HashMap::new()],
             string_map: HashMap::new(),
             ctor_map: HashMap::new(),
+            next_tag: 0,
             evidence_scope: HashMap::new(),
             func_map: HashMap::new(),
             recur_target: None,
@@ -224,7 +229,6 @@ impl<'a> Lower<'a> {
         if args.is_empty() {
             return;
         }
-        let mut tag: u16 = 0;
         for arg in &args[1..] {
             match &arg.kind {
                 ExprKind::List(items) if !items.is_empty() => {
@@ -248,25 +252,27 @@ impl<'a> Lower<'a> {
                                 .count() as u16;
                             let total = if kw_count > 0 { kw_count } else { field_count };
 
+                            let tag = self.next_tag;
+                            self.next_tag += 1;
                             self.ctor_map.insert(name.clone(), (tag, total));
                             self.module.ctors.push(Ctor {
                                 name: name.clone(),
                                 tag,
                                 arity: total,
                             });
-                            tag += 1;
                         }
                     }
                 }
                 ExprKind::Symbol(name) if name.starts_with(char::is_uppercase) => {
                     // Nullary constructor
+                    let tag = self.next_tag;
+                    self.next_tag += 1;
                     self.ctor_map.insert(name.clone(), (tag, 0));
                     self.module.ctors.push(Ctor {
                         name: name.clone(),
                         tag,
                         arity: 0,
                     });
-                    tag += 1;
                 }
                 _ => {} // type params etc
             }
@@ -1637,19 +1643,21 @@ impl<'a> Lower<'a> {
                 }
             }
 
+            // Check for a user-defined function FIRST, so a [fn name …] shadows
+            // a builtin of the same name (e.g. defining `sum` overrides the
+            // builtin `sum`) rather than being silently ignored.
+            if let Some(&func_id) = self.func_map.get(name.as_str()) {
+                let args: Vec<Reg> = arg_exprs.iter().map(|e| self.lower_expr(e)).collect();
+                let r = self.reg();
+                self.emit(Op::Call(r, func_id, args, span));
+                return r;
+            }
+
             // Check for known builtins
             if let Some(built) = self.resolve_builtin(name) {
                 let args: Vec<Reg> = arg_exprs.iter().map(|e| self.lower_expr(e)).collect();
                 let r = self.reg();
                 self.emit(Op::Builtin(r, built, args, span));
-                return r;
-            }
-
-            // Check for known function by name
-            if let Some(&func_id) = self.func_map.get(name.as_str()) {
-                let args: Vec<Reg> = arg_exprs.iter().map(|e| self.lower_expr(e)).collect();
-                let r = self.reg();
-                self.emit(Op::Call(r, func_id, args, span));
                 return r;
             }
         }

--- a/crates/loon-lang/src/eir/vm.rs
+++ b/crates/loon-lang/src/eir/vm.rs
@@ -2047,6 +2047,27 @@ mod tests {
     }
 
     #[test]
+    fn vm_ctor_tags_globally_unique() {
+        // Constructors of different types must not collide: P (first ctor of B)
+        // and X (first ctor of A) used to share per-type tag 0, so [X n] matched
+        // a P value. Tags are now globally unique.
+        let v = run("[type A [X Int] [Y]] [type B [P Int] [Q]] \
+                     [match [P 5] [X n] 1 [Y] 2 [P n] n [Q] 4]");
+        assert_eq!(v.as_int(), 5);
+        let v = run("[type A [X Int] [Y]] [type B [P Int] [Q]] \
+                     [match [Y] [X n] 1 [Y] 2 [P n] 3 [Q] 4]");
+        assert_eq!(v.as_int(), 2);
+    }
+
+    #[test]
+    fn vm_user_fn_shadows_builtin() {
+        // A user [fn sum …] overrides the builtin `sum` instead of being ignored.
+        assert_eq!(run("[fn sum [x] 99] [sum #[1 2 3]]").as_int(), 99);
+        // Builtins still resolve when not shadowed.
+        assert_eq!(run("[sum #[1 2 3]]").as_int(), 6);
+    }
+
+    #[test]
     fn vm_structural_equality() {
         // Strings compare by content, not by heap identity: two independently
         // computed strings are equal (this used to be false — pointer equality).

--- a/docs/elegance-notes.md
+++ b/docs/elegance-notes.md
@@ -34,20 +34,18 @@ Legend: **break?** = backward-incompatible · **effort** S/M/L.
    effects must be declared. **Fix:** either declare everything (with a `prelude`
    of standard effects) or document a fixed built-in set. _break? maybe · S_
 
-4b. **Builtins shadow user `fn` definitions.** Defining `[fn sum …]` does *not*
-   override the builtin `sum` — `[sum xs]` still calls the builtin (discovered
-   when a self-hosted test silently computed against the builtin instead of the
-   user's recursive `sum`). User definitions should win, or at least collide
-   loudly. **Fix:** user `fn` (and `let`) bindings shadow builtins; warn on
-   shadow. _break? yes (subtle) · effort S_
+4b. **✅ FIXED — user `fn` definitions now shadow builtins.** `lower_call`
+   checked the builtin table before user functions, so `[fn sum …]` was silently
+   ignored in favor of the builtin `sum`. It now resolves user functions first;
+   builtins still resolve when not shadowed. (Operators and constructors keep
+   priority.) See `lower_call` in `eir/lower.rs`.
 
-4c. **`match` does not discriminate constructors across different types.** A
-   pattern `[LCtx a b c d]` happily matched a `[VB s i]` value (a different
-   type, even different arity) — match appears to assume the scrutinee has the
-   pattern's type and only discriminates *within* a type. This silently binds
-   garbage when a heterogeneous collection holds values of several types.
-   **Fix:** match should check the constructor's owning type/tag, not just shape.
-   _break? yes (catches latent bugs) · effort M_
+4c. **✅ FIXED — constructor tags are globally unique.** Tags were assigned per
+   type starting at 0, so the first constructor of every type shared tag 0;
+   `match` (which lowers to a runtime tag-equality check) would match a pattern
+   of one type against a value of another with the same ordinal — e.g. `[Some n]`
+   vs a `[Cons …]` value — and bind garbage. `collect_ctors` now uses a global
+   `next_tag` counter, so distinct constructors never collide. See `eir/lower.rs`.
 
 4d. **Maps are unordered (hash order).** `keys`, iteration, and display of a map
    come back in an unpredictable order — `[assoc [assoc {:x 1} :y 2] :z 3]`


### PR DESCRIPTION
The final elegance batch — two **correctness** fixes we hit head-on while self-hosting, both localized to the EIR lowerer.

## #4c — cross-type `match` leak (silent garbage)
`collect_ctors` assigned constructor tags **per type, starting at 0**, so the first constructor of *every* type shared tag `0`, the second shared `1`, etc. Since `match` lowers a constructor pattern to a runtime tag-equality check, a pattern of one type matched a value of **another** type with the same ordinal:

```
[type Opt [Some Int] [None]]   ; Some=0, None=1
[type Lst [Cons Int Lst] [Nil]] ; Cons=0, Nil=1  (collision!)
[match [Cons 9 [Nil]] [Some n] "some" ...]  ; used to match [Some n] and bind garbage
```

This is exactly what bit the self-hosted compiler (a `[LCtx …]` pattern matched a `[VB …]` value, forcing a workaround). Fix: tags now come from a **global `next_tag` counter** on the lowerer, so distinct constructors never collide.

## #4b — user functions now shadow builtins
`lower_call` checked the builtin table **before** user functions, so defining `[fn sum …]` was silently ignored in favor of the builtin `sum`:

```
[fn sum [xs] …custom…] [sum xs]   ; used to call the BUILTIN sum, not yours
```

It now resolves user functions first; builtins still resolve when not shadowed. Operators (`+`, `=`, `not`, …) and constructors keep priority.

```
[fn sum [x] 99] [sum #[1 2 3]]   ; => 99 (user fn wins)
[sum #[1 2 3]]                   ; => 6  (builtin still works)
```

## Tests
- New `vm_ctor_tags_globally_unique`, `vm_user_fn_shadows_builtin`.
- Full `loon-lang` + `loon-cli` suites pass.
- All self-hosted gates green: inline (read/expand/eir), differential (check/own/eir), and the four self-application gates (f2/expand-vm/infer-vm/own-vm).

## Deferred (intentionally not bundled)
- **#4d unordered maps** — a real fix needs a custom *insertion-ordered persistent map* (imbl has no insertion-ordered map; `OrdMap` sorts by key, and heap-pointer key order isn't stable). Touches every map op + the interp — its own PR.
- **#2 `{`-in-strings** — needs a syntax/sigil decision (e.g. Swift-style `\(…)`), the one genuinely design-flavored choice. Worth deciding before implementing.

With this, every wart we hit while self-hosting that's fixable without a design call is fixed: structural `=` (#37), string→number (#38), and now ctor tags + builtin shadowing.

https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus)_