### PR TITLE
Elegance: insertion-ordered maps in the EIR VM (#4d)

### DIFF
--- a/crates/loon-lang/src/eir/vm.rs
+++ b/crates/loon-lang/src/eir/vm.rs
@@ -12,8 +12,88 @@ use std::rc::Rc;
 
 // Persistent collection types — O(log n) clone via structural sharing.
 type ImVec = imbl::Vector<Val>;
-type ImMap = imbl::HashMap<Val, Val>;
 type ImSet = imbl::HashSet<Val>;
+type ImMap = OrdMap;
+
+/// An insertion-ordered persistent map. `keys`, iteration, and display follow
+/// the order keys were first inserted (deterministic), rather than hash order.
+/// Lookup stays O(1) via the inner `HashMap`; an `imbl::Vector` of keys records
+/// order. Both halves are persistent, so clone/share is still cheap. Mirrors the
+/// subset of `imbl::HashMap`'s API the VM uses, so it's a drop-in for the alias.
+#[derive(Debug, Clone, Default)]
+struct OrdMap {
+    map: imbl::HashMap<Val, Val>,
+    order: imbl::Vector<Val>, // keys, insertion order, no duplicates
+}
+
+impl OrdMap {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn len(&self) -> usize {
+        self.order.len()
+    }
+    fn is_empty(&self) -> bool {
+        self.order.is_empty()
+    }
+    fn get(&self, k: &Val) -> Option<&Val> {
+        self.map.get(k)
+    }
+    fn contains_key(&self, k: &Val) -> bool {
+        self.map.contains_key(k)
+    }
+    /// Insert; a brand-new key is appended to the order, an existing key keeps
+    /// its position (only its value updates). Returns the previous value, if any.
+    fn insert(&mut self, k: Val, v: Val) -> Option<Val> {
+        let prev = self.map.insert(k, v);
+        if prev.is_none() {
+            self.order.push_back(k);
+        }
+        prev
+    }
+    fn keys(&self) -> impl Iterator<Item = &Val> + '_ {
+        self.order.iter()
+    }
+    fn values(&self) -> impl Iterator<Item = &Val> + '_ {
+        self.order.iter().map(move |k| self.map.get(k).unwrap())
+    }
+    fn iter(&self) -> impl Iterator<Item = (&Val, &Val)> + '_ {
+        self.order.iter().map(move |k| (k, self.map.get(k).unwrap()))
+    }
+    /// Left-biased union (values already in `self` win), preserving `self`'s
+    /// order and appending `other`'s new keys in their order.
+    fn union(&self, other: Self) -> Self {
+        let mut out = self.clone();
+        for k in other.order.iter() {
+            if !out.map.contains_key(k) {
+                out.insert(*k, *other.map.get(k).unwrap());
+            }
+        }
+        out
+    }
+}
+
+impl FromIterator<(Val, Val)> for OrdMap {
+    fn from_iter<I: IntoIterator<Item = (Val, Val)>>(iter: I) -> Self {
+        let mut m = OrdMap::new();
+        for (k, v) in iter {
+            m.insert(k, v);
+        }
+        m
+    }
+}
+
+impl IntoIterator for OrdMap {
+    type Item = (Val, Val);
+    type IntoIter = std::vec::IntoIter<(Val, Val)>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.order
+            .iter()
+            .map(|k| (*k, *self.map.get(k).unwrap()))
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+}
 
 // ─── Heap objects ──────────────────────────────────────────────────────────
 
@@ -2057,6 +2137,24 @@ mod tests {
         let v = run("[type A [X Int] [Y]] [type B [P Int] [Q]] \
                      [match [Y] [X n] 1 [Y] 2 [P n] 3 [Q] 4]");
         assert_eq!(v.as_int(), 2);
+    }
+
+    #[test]
+    fn vm_map_insertion_order() {
+        // keys / display follow insertion order deterministically (not hash
+        // order). assoc of an existing key keeps its position; a new key appends.
+        assert_eq!(
+            run_output(r#"[println [keys [assoc [assoc {:x 1} :y 2] :z 3]]]"#),
+            vec!["#[:x :y :z]"]
+        );
+        assert_eq!(
+            run_output(r#"[println [assoc [assoc {:x 1} :y 2] :x 9]]"#),
+            vec!["{:x 9 :y 2}"]
+        );
+        assert_eq!(
+            run_output(r#"[println {:a 1 :b 2 :c 3}]"#),
+            vec!["{:a 1 :b 2 :c 3}"]
+        );
     }
 
     #[test]

--- a/docs/elegance-notes.md
+++ b/docs/elegance-notes.md
@@ -47,12 +47,14 @@ Legend: **break?** = backward-incompatible · **effort** S/M/L.
    vs a `[Cons …]` value — and bind garbage. `collect_ctors` now uses a global
    `next_tag` counter, so distinct constructors never collide. See `eir/lower.rs`.
 
-4d. **Maps are unordered (hash order).** `keys`, iteration, and display of a map
-   come back in an unpredictable order — `[assoc [assoc {:x 1} :y 2] :z 3]`
-   prints `{:z 3 :x 1 :y 2}`. This makes map output non-deterministic and
-   annoying to test. The self-hosted VM uses insertion-ordered maps, which are
-   deterministic and (for small maps) what people expect. **Fix:** make the
-   runtime maps insertion-ordered too. _break? maybe · effort M_
+4d. **✅ FIXED — maps are insertion-ordered.** `keys`, iteration, and display
+   used to come back in hash order (non-deterministic): `[assoc [assoc {:x 1}
+   :y 2] :z 3]` printed `{:z 3 :x 1 :y 2}`. The EIR VM's map is now an
+   insertion-ordered persistent map (`OrdMap` in `eir/vm.rs`: an `imbl::HashMap`
+   for O(1) lookup + an `imbl::Vector` of keys for order), so it prints
+   `{:x 1 :y 2 :z 3}` deterministically — matching the self-hosted VM. (The
+   legacy tree-walking interpreter still uses an unordered `imbl::HashMap`; a
+   follow-up could align it.)
 
 5. **`let` is a body statement, not an expression.** `[let x v]` scopes to the
    rest of the enclosing body — clean in sequences, but `[let …]` can't be used

--- a/src/frontend/tests/eir/maps.oo
+++ b/src/frontend/tests/eir/maps.oo
@@ -4,9 +4,11 @@
       [recur [+ k 1] [conj acc [get m [nth ks k]]]]]]]
 [fn main []
   [let m [assoc [assoc {:x 1} :y 2] :z 3]]
-  ; order-independent: Loon maps are hash-ordered, the self-hosted VM's are
-  ; insertion-ordered, so avoid comparing key order / map display here.
   [println [join "," [lookup-all m #[:x :y :z]]]]
   [println [len m]]
   [println [if [contains? m :y] "has-y" "no-y"]]
-  [println [get m :missing]]]
+  [println [get m :missing]]
+  ; now order-deterministic and consistent with the VM:
+  [println [join "," [keys m]]]
+  [println m]
+  [println [assoc m :x 99]]]


### PR DESCRIPTION
Fixes wart #4d — maps are now **insertion-ordered** in the EIR VM.

## The problem
Map `keys`, iteration, and display came back in hash order, so map output was non-deterministic:

```
[assoc [assoc {:x 1} :y 2] :z 3]   ; printed {:z 3 :x 1 :y 2}
```

Annoying to read, impossible to test against, and it diverged from the self-hosted VM (which uses insertion-ordered maps) — we had to *weaken* `tests/eir/maps.oo` to order-independent ops because of exactly this.

## The fix
The VM's map type is now `OrdMap`, an insertion-ordered persistent map:
- an `imbl::HashMap<Val, Val>` for **O(1) lookup**, plus
- an `imbl::Vector<Val>` of keys recording **first-insertion order**.

Both halves are persistent, so clone/share stays cheap. `OrdMap` mirrors the subset of `imbl::HashMap`'s API the VM already used (`new`/`get`/`insert`/`contains_key`/`len`/`is_empty`/`iter`/`keys`/`values`/`union`/`FromIterator`/`IntoIterator`), so it's a drop-in for the type alias — no call-site churn. `assoc` of an existing key keeps its position; a new key appends; `union` is left-biased and order-preserving.

```
{:a 1 :b 2 :c 3}                    ; => {:a 1 :b 2 :c 3}  (deterministic)
[keys [assoc [assoc {:x 1} :y 2] :z 3]] ; => #[:x :y :z]
[assoc {:x 1 :y 2} :x 9]            ; => {:x 9 :y 2}  (keeps position)
```

This now **matches the self-hosted VM**, so `tests/eir/maps.oo` is restored to assert key order + display (no longer weakened).

## Tests
- New `vm_map_insertion_order` + strengthened `tests/eir/maps.oo` differential.
- Full `loon-lang` + `loon-cli` suites pass.
- All self-hosted gates green (inline, differential, four self-application gates).

## Note
The legacy tree-walking interpreter still uses an unordered `imbl::HashMap`; aligning it is a small follow-up if desired.

With this, **all four `#4` warts are fixed** (builtin shadowing, cross-type match, and now unordered maps), plus structural `=` and string→number from earlier. Only **#2 (`{`-in-strings)** remains — and that one needs a syntax/sigil decision.

https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus)_