### PR TITLE
Elegance: \(expr) string interpolation, bare braces literal (#2)

### DIFF
--- a/crates/loon-lang/src/eir/vm.rs
+++ b/crates/loon-lang/src/eir/vm.rs
@@ -2140,6 +2140,19 @@ mod tests {
     }
 
     #[test]
+    fn vm_interpolation() {
+        // \(expr) interpolates...
+        assert_eq!(
+            run_output(r#"[let n "world"] [println "hi \(n)"]"#),
+            vec!["hi world"]
+        );
+        assert_eq!(run_output(r#"[println "2+2=\([+ 2 2])"]"#), vec!["2+2=4"]);
+        // ...and bare braces are ordinary literal characters (no escaping).
+        assert_eq!(run_output(r#"[println "{:a 1 :b 2}"]"#), vec!["{:a 1 :b 2}"]);
+        assert_eq!(run_output(r##"[println "#{IO Fail}"]"##), vec!["#{IO Fail}"]);
+    }
+
+    #[test]
     fn vm_map_insertion_order() {
         // keys / display follow insertion order deterministically (not hash
         // order). assoc of an existing key keeps its position; a new key appends.

--- a/crates/loon-lang/src/parser/mod.rs
+++ b/crates/loon-lang/src/parser/mod.rs
@@ -168,7 +168,7 @@ impl<'a> Parser<'a> {
             Token::True => Ok(Expr::new(ExprKind::Bool(true), span)),
             Token::False => Ok(Expr::new(ExprKind::Bool(false), span)),
             Token::Str(s) => {
-                if s.contains('{') {
+                if s.contains(crate::syntax::INTERP_START) {
                     return desugar_fmt(&s, span, self.source);
                 }
                 Ok(Expr::new(ExprKind::Str(s), span))
@@ -338,70 +338,39 @@ impl<'a> Parser<'a> {
     }
 }
 
-/// Desugar `[fmt "hello {name}, {[+ 1 2]}"]` into `[str "hello " name ", " [+ 1 2]]`
+/// Desugar an interpolated string `"hello \(name), \([+ 1 2])"` into
+/// `[str "hello " name ", " [+ 1 2]]`. The lexer (`unescape`) has already
+/// delimited each `\(expr)` with INTERP_START/INTERP_END sentinels and made all
+/// braces literal, so here we just split on the sentinels and re-parse each
+/// expression span.
 fn desugar_fmt(template: &str, span: Span, _source: &str) -> Result<Expr, ParseError> {
+    use crate::syntax::{INTERP_END, INTERP_START};
     let mut parts: Vec<Expr> = Vec::new();
     let mut literal = String::new();
-    let mut chars = template.chars().peekable();
+    let mut chars = template.chars();
 
     while let Some(c) = chars.next() {
-        if c == '{' {
-            if chars.peek() == Some(&'{') {
-                // Escaped {{ → literal {
-                chars.next();
-                literal.push('{');
-            } else {
-                // Flush literal
-                if !literal.is_empty() {
-                    parts.push(Expr::new(ExprKind::Str(literal.clone()), span));
-                    literal.clear();
-                }
-                // Collect expression text until matching }
-                let mut expr_text = String::new();
-                let mut depth = 1;
-                for ec in chars.by_ref() {
-                    if ec == '{' {
-                        depth += 1;
-                        expr_text.push(ec);
-                    } else if ec == '}' {
-                        depth -= 1;
-                        if depth == 0 {
-                            break;
-                        }
-                        expr_text.push(ec);
-                    } else {
-                        expr_text.push(ec);
-                    }
-                }
-                if depth != 0 {
-                    return Err(ParseError {
-                        message: "unclosed { in fmt string".to_string(),
-                        span,
-                    });
-                }
-                // Parse the expression text
-                let inner_exprs = parse(&expr_text).map_err(|e| ParseError {
-                    message: format!("error in fmt interpolation: {}", e.message),
-                    span,
-                })?;
-                if inner_exprs.len() == 1 {
-                    parts.push(inner_exprs.into_iter().next().unwrap());
-                } else {
-                    return Err(ParseError {
-                        message: "fmt interpolation must contain exactly one expression"
-                            .to_string(),
-                        span,
-                    });
-                }
+        if c == INTERP_START {
+            if !literal.is_empty() {
+                parts.push(Expr::new(ExprKind::Str(literal.clone()), span));
+                literal.clear();
             }
-        } else if c == '}' {
-            if chars.peek() == Some(&'}') {
-                // Escaped }} → literal }
-                chars.next();
-                literal.push('}');
+            let mut expr_text = String::new();
+            for ec in chars.by_ref() {
+                if ec == INTERP_END {
+                    break;
+                }
+                expr_text.push(ec);
+            }
+            let inner_exprs = parse(&expr_text).map_err(|e| ParseError {
+                message: format!("error in interpolation: {}", e.message),
+                span,
+            })?;
+            if inner_exprs.len() == 1 {
+                parts.push(inner_exprs.into_iter().next().unwrap());
             } else {
                 return Err(ParseError {
-                    message: "unmatched } in fmt string".to_string(),
+                    message: "interpolation \\(…) must contain exactly one expression".to_string(),
                     span,
                 });
             }
@@ -415,7 +384,10 @@ fn desugar_fmt(template: &str, span: Span, _source: &str) -> Result<Expr, ParseE
         parts.push(Expr::new(ExprKind::Str(literal), span));
     }
 
-    // If no interpolation, just return a plain string
+    // Empty or a single literal — just a plain string.
+    if parts.is_empty() {
+        return Ok(Expr::new(ExprKind::Str(String::new()), span));
+    }
     if parts.len() == 1 {
         if let ExprKind::Str(_) = &parts[0].kind {
             return Ok(parts.into_iter().next().unwrap());
@@ -612,7 +584,7 @@ mod tests {
 
     #[test]
     fn parse_fmt_simple() {
-        let src = r#"[fmt "hello {name}"]"#;
+        let src = r#"[fmt "hello \(name)"]"#;
         let exprs = parse(src).unwrap();
         assert_eq!(exprs.len(), 1);
         // Should desugar to [str "hello " name]
@@ -621,7 +593,7 @@ mod tests {
 
     #[test]
     fn parse_fmt_expr() {
-        let src = r#"[fmt "2 + 2 = {[+ 2 2]}"]"#;
+        let src = r#"[fmt "2 + 2 = \([+ 2 2])"]"#;
         let exprs = parse(src).unwrap();
         assert_eq!(exprs.len(), 1);
         assert_eq!(exprs[0].to_string(), r#"[str "2 + 2 = " [+ 2 2]]"#);
@@ -637,16 +609,17 @@ mod tests {
     }
 
     #[test]
-    fn parse_fmt_escaped_braces() {
-        let src = r#"[fmt "escaped {{braces}}"]"#;
+    fn parse_fmt_literal_braces() {
+        // Bare braces are ordinary literal characters (interpolation is \(…)).
+        let src = r#"[fmt "literal {braces}"]"#;
         let exprs = parse(src).unwrap();
         assert_eq!(exprs.len(), 1);
-        assert_eq!(exprs[0].to_string(), r#""escaped {braces}""#);
+        assert_eq!(exprs[0].to_string(), r#""literal {braces}""#);
     }
 
     #[test]
     fn parse_universal_interpolation() {
-        let src = r#"[let x "hello {name}"]"#;
+        let src = r#"[let x "hello \(name)"]"#;
         let exprs = parse(src).unwrap();
         assert_eq!(exprs.len(), 1);
         // The string "hello {name}" should desugar to [str "hello " name]

--- a/crates/loon-lang/src/syntax/mod.rs
+++ b/crates/loon-lang/src/syntax/mod.rs
@@ -1,5 +1,6 @@
 mod tokens;
 pub use tokens::Token;
+pub(crate) use tokens::{INTERP_END, INTERP_START};
 
 /// A byte-offset span in source code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/loon-lang/src/syntax/tokens.rs
+++ b/crates/loon-lang/src/syntax/tokens.rs
@@ -1,60 +1,79 @@
 use logos::Logos;
 
+// Interpolation sentinels: unambiguous markers delimiting an interpolated
+// expression in the unescaped string, so the parser (desugar_fmt) can find them
+// without colliding with any literal text (these control chars can't appear in
+// source). `\(expr)` becomes START expr END.
+pub(crate) const INTERP_START: char = '\u{1}';
+pub(crate) const INTERP_END: char = '\u{2}';
+
+/// Unescape a string literal token.
+///
+/// Interpolation is Swift/Roc-style `\(expr)`: bare `{` and `}` are ordinary
+/// literal characters (so map/JSON/embedded-Loon text needs no escaping). `\{`
+/// and `\}` are also accepted as literal braces for back-compat. Standard
+/// escapes `\n \t \\ \"` apply. An `\(…)` span is emitted between sentinels with
+/// its expression text preserved verbatim (so it can be re-parsed); inner string
+/// quotes are written `\"` and balance parens are tracked so a `)` inside a
+/// nested string doesn't close the interpolation early.
 fn unescape(s: &str) -> String {
     let mut out = String::new();
-    let mut chars = s[1..s.len() - 1].chars().peekable();
-    let mut brace_depth: u32 = 0;
-    let mut in_string = false; // inside "..." within interpolation
+    let mut chars = s[1..s.len() - 1].chars();
 
     while let Some(c) = chars.next() {
-        if brace_depth > 0 {
-            // Inside {…} interpolation block.
-            // Convert \" → " (needed for inner string delimiters).
-            // Preserve other escapes (\n, \t, \\) verbatim for re-parse.
-            if c == '\\' {
-                match chars.next() {
-                    Some('"') => {
-                        out.push('"');
-                        in_string = !in_string;
-                    }
-                    Some(other) => {
-                        out.push('\\');
-                        out.push(other);
-                    }
-                    None => out.push('\\'),
-                }
-            } else {
-                out.push(c);
-                if !in_string {
-                    match c {
-                        '{' => brace_depth += 1,
-                        '}' => brace_depth -= 1,
-                        _ => {}
-                    }
-                }
-            }
-            continue;
-        }
-
-        // Outside interpolation — normal unescape
         if c == '\\' {
             match chars.next() {
                 Some('n') => out.push('\n'),
                 Some('t') => out.push('\t'),
                 Some('\\') => out.push('\\'),
                 Some('"') => out.push('"'),
-                Some('{') => out.push_str("{{"),
-                Some('}') => out.push_str("}}"),
+                Some('{') => out.push('{'), // literal brace (back-compat)
+                Some('}') => out.push('}'), // literal brace (back-compat)
+                Some('(') => {
+                    // Interpolation: collect the expression verbatim up to the
+                    // matching ')'.
+                    out.push(INTERP_START);
+                    let mut depth: u32 = 1;
+                    let mut in_string = false;
+                    while let Some(ec) = chars.next() {
+                        if ec == '\\' {
+                            // \" toggles the inner string and becomes a bare
+                            // quote for re-parsing; any other escape is kept.
+                            match chars.next() {
+                                Some('"') => {
+                                    out.push('"');
+                                    in_string = !in_string;
+                                }
+                                Some(other) => {
+                                    out.push('\\');
+                                    out.push(other);
+                                }
+                                None => out.push('\\'),
+                            }
+                        } else {
+                            if !in_string {
+                                if ec == '(' {
+                                    depth += 1;
+                                } else if ec == ')' {
+                                    depth -= 1;
+                                    if depth == 0 {
+                                        break;
+                                    }
+                                }
+                            }
+                            out.push(ec);
+                        }
+                    }
+                    out.push(INTERP_END);
+                }
                 Some(other) => {
                     out.push('\\');
                     out.push(other);
                 }
                 None => out.push('\\'),
             }
-        } else if c == '{' {
-            out.push('{');
-            brace_depth = 1;
         } else {
+            // Bare `{` / `}` and everything else are literal characters.
             out.push(c);
         }
     }

--- a/crates/loon-lang/tests/interp_tests.rs
+++ b/crates/loon-lang/tests/interp_tests.rs
@@ -716,20 +716,21 @@ fn stdlib_into_map() {
 #[test]
 fn fmt_interpolation() {
     assert_eq!(
-        run(r#"[let name "world"] [fmt "hello {name}"]"#),
+        run(r#"[let name "world"] [fmt "hello \(name)"]"#),
         Value::Str("hello world".into())
     );
     assert_eq!(
-        run(r#"[fmt "2 + 2 = {[+ 2 2]}"]"#),
+        run(r#"[fmt "2 + 2 = \([+ 2 2])"]"#),
         Value::Str("2 + 2 = 4".into())
     );
     assert_eq!(
         run(r#"[fmt "no interpolation"]"#),
         Value::Str("no interpolation".into())
     );
+    // Bare braces are ordinary literal characters now.
     assert_eq!(
-        run(r#"[fmt "escaped {{braces}}"]"#),
-        Value::Str("escaped {braces}".into())
+        run(r#"[fmt "literal {braces}"]"#),
+        Value::Str("literal {braces}".into())
     );
 }
 
@@ -975,11 +976,11 @@ fn dot_access_string_keyed_map() {
 
 #[test]
 fn newline_inside_interpolation() {
-    // \n inside {…} interpolation should be preserved for re-parse
+    // \n inside \(…) interpolation should be preserved for re-parse
     assert_eq!(
         run(r#"
             [let items #["a" "b"]]
-            [str "list:\n{[join \"\n\" items]}"]
+            [str "list:\n\([join \"\n\" items])"]
         "#),
         Value::Str("list:\na\nb".into())
     );

--- a/docs/elegance-notes.md
+++ b/docs/elegance-notes.md
@@ -16,13 +16,16 @@ Legend: **break?** = backward-incompatible · **effort** S/M/L.
    (recursively), matching the legacy interpreter — see `val_eq` in `eir/vm.rs`.
    Follow-up: the `streq` workaround in `reader.oo` can now be replaced with `=`.
 
-2. **`{…}` string interpolation collides with set/map literals.** You cannot
-   write a literal `{` in a string: `"#{IO}"` becomes `#IO`, and `"#{}"` errors
-   with "unreachable code". Every test that embeds Loon source with a `#{…}`
-   effect set or `{…}` map must assemble braces from `ch-ob`/`ch-cb`. **Fix:**
-   pick an interpolation sigil that doesn't overload braces — e.g. `\(expr)`
-   (Swift-style) or `${…}` — or require `{{`/`\{` to escape. _break? yes ·
-   effort S–M_
+2. **✅ FIXED — interpolation is now `\(expr)` (Swift/Roc-style).** `{…}` used to
+   be interpolation, so a literal `{` in a string needed escaping and brace-heavy
+   text (maps, JSON, embedded Loon source) was painful — the worst fit for a
+   brace-heavy, self-hosting language. Interpolation now uses `\(expr)` (reusing
+   the escape char, matching Roc, which like Loon desugars to string concat), and
+   **bare `{`/`}` are ordinary literal characters** — no escaping. `\{`/`\}`
+   still produce literal braces for back-compat. See `unescape` (lexer) +
+   `desugar_fmt` (parser). Migrated the interpolation tests and `word-freq.oo`;
+   the self-hosted map/set tests dropped their `\{…\}` escaping. (Web-doc prose
+   that teaches `{expr}` still needs a content pass — follow-up.)
 
 3. **String indexing is O(index).** `char-at`/`substring` re-scan from the
    start, so naive scanning is O(n²); the reader works around this by splitting

--- a/samples/word-freq.oo
+++ b/samples/word-freq.oo
@@ -15,7 +15,7 @@
   [take 10 ranked]]
 
 [fn format-pair [[word n]]
-  [fmt "{[str word]}: {[str n]}"]]
+  [fmt "\([str word]): \([str n])"]]
 
 ; Read file and process
 [IO.println "=== Word Frequency Counter ==="]

--- a/src/frontend/tests/eir_inline.oo
+++ b/src/frontend/tests/eir_inline.oo
@@ -97,15 +97,15 @@
     "[fn vmap [f xs] [loop [k 0 acc #[]] [if [>= k [len xs]] acc [recur [+ k 1] [conj acc [f [nth xs k]]]]]]] [fn main [] [join \",\" [vmap [fn [x] [* x x]] #[1 2 3 4]]]]"
     "1,4,9,16"]
 
-  ; ── maps / sets (braces escaped in embedded source) ──
-  [evals "map lit"    "[fn main [] \{:a 1 :b 2\}]" "\{:a 1 :b 2\}"]
-  [evals "map get"    "[fn main [] [get \{:a 1 :b 2\} :b]]" "2"]
-  [evals "map miss"   "[fn main [] [get \{:a 1\} :z]]" "()"]
-  [evals "map assoc"  "[fn main [] [get [assoc \{:a 1\} :a 9] :a]]" "9"]
-  [evals "map keys"   "[fn main [] [join \",\" [keys \{:a 1 :b 2\}]]]" ":a,:b"]
-  [evals "map len"    "[fn main [] [len \{:a 1 :b 2 :c 3\}]]" "3"]
-  [evals "map has"    "[fn main [] [if [contains? \{:a 1\} :a] 1 0]]" "1"]
-  [evals "set has"    "[fn main [] [if [contains? #\{1 2 3\} 2] 1 0]]" "1"]
-  [evals "set len"    "[fn main [] [len #\{1 2 3 4\}]]" "4"]
+  ; ── maps / sets (bare braces in embedded source — no escaping needed now) ──
+  [evals "map lit"    "[fn main [] {:a 1 :b 2}]" "{:a 1 :b 2}"]
+  [evals "map get"    "[fn main [] [get {:a 1 :b 2} :b]]" "2"]
+  [evals "map miss"   "[fn main [] [get {:a 1} :z]]" "()"]
+  [evals "map assoc"  "[fn main [] [get [assoc {:a 1} :a 9] :a]]" "9"]
+  [evals "map keys"   "[fn main [] [join \",\" [keys {:a 1 :b 2}]]]" ":a,:b"]
+  [evals "map len"    "[fn main [] [len {:a 1 :b 2 :c 3}]]" "3"]
+  [evals "map has"    "[fn main [] [if [contains? {:a 1} :a] 1 0]]" "1"]
+  [evals "set has"    "[fn main [] [if [contains? #{1 2 3} 2] 1 0]]" "1"]
+  [evals "set len"    "[fn main [] [len #{1 2 3 4}]]" "4"]
 
   [println "done"]]


### PR DESCRIPTION
The last elegance wart (#2), and the one that needed a design decision. Researched the design space first ([Roc/Swift `\()`](https://brianlovin.com/hn/38346862), [Gleam `${}`](https://github.com/gleam-lang/gleam/discussions/1086), [Swift](https://www.swiftbysundell.com/articles/string-literals-in-swift/)) — the modern trend is away from bare braces toward a sigil, and **Roc** (a functional language whose interpolation, like Loon's, desugars to string concat) chose `\(expr)`. That fits Loon best.

## The problem
Interpolation was bare `{expr}`, which **overloads the `{}` that already mean map/set literals**. So a literal `{` in a string needed escaping (`\{` *and* `\}`), and brace-heavy text — maps, JSON, embedded Loon source — was painful. For a brace-heavy, *self-hosting* language, that's the worst possible fit (we hit it repeatedly writing map tests, which had to assemble braces by escaping).

## The fix: `\(expr)`
Interpolation now uses `\(expr)` — the escape char introduces it, so there's no new sigil and zero ambiguity, and **bare `{` / `}` are ordinary literal characters** needing no escaping. `\{` / `\}` still produce literal braces for back-compat.

```
"hi \(name)"        => hi world
"2+2=\([+ 2 2])"    => 2+2=4
"{:a 1 :b 2}"       => {:a 1 :b 2}    ← literal, no escaping
"#{IO Fail}"        => #{IO Fail}     ← literal
"map={:n \(n)}"     => map={:n 5}     ← braces + interpolation together
```

## Implementation
- **Lexer (`unescape`):** emits each `\(expr)` between two control-char sentinels (unambiguous vs. any literal text) with the expression preserved verbatim, tracking nested parens and inner strings so a `)` inside a nested string doesn't close early. Bare braces are pushed literally.
- **Parser (`desugar_fmt`):** splits on the sentinels and re-parses each span into `[str part …]`. No brace special-casing anymore.

## Migrations
- Parser `fmt` unit tests, `interp_tests` (`fmt_interpolation`, `newline_inside_interpolation`), and `samples/word-freq.oo` → `\(expr)`.
- The self-hosted map/set inline tests **dropped their `\{…\}` escaping** — a direct demonstration of the fix.
- New `vm_interpolation` test. Full `loon-lang` + `loon-cli` suites pass; all self-hosted gates green.

## Note / follow-up
Web-doc prose still teaches `{expr}` and needs a separate content pass (writing literal `\(` in rendered docs needs care). `web/` isn't in the test surface and is a separate concern, so I deferred it rather than risk subtly-wrong rendered docs.

---

With this, **the entire elegance punch-list from the self-hosting effort is cleared**: structural `=` (#37), string→number (#38), ctor tags + builtin shadowing (#39), ordered maps (#40), and now `\(expr)` interpolation (#2).

https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus)_