### PR TITLE
Effects: escaping continuations — a pure State effect works

### DIFF
--- a/crates/loon-lang/src/eir/vm.rs
+++ b/crates/loon-lang/src/eir/vm.rs
@@ -118,6 +118,9 @@ enum Obj {
         regs: Vec<Val>,
         captures: Vec<Val>,
         perform_dst: u32,
+        /// The handle's handlers, so a continuation resumed AFTER its `handle`
+        /// has exited (an escaping continuation) can re-establish them.
+        prompt_handlers: Vec<DynHandler>,
         used: bool,
     },
 }
@@ -160,6 +163,7 @@ struct Frame {
 // ─── VM ────────────────────────────────────────────────────────────────────
 
 /// Dynamic effect handler entry.
+#[derive(Clone, Debug)]
 struct DynHandler {
     /// String pool index for the effect name.
     effect: StringId,
@@ -449,41 +453,72 @@ impl Vm {
     }
 
     /// Resume a one-shot delimited continuation `k` with value `v`: re-install
-    /// the captured frame segment on top of the stack and continue at the
-    /// perform point with `v` plugged in. The segment's eventual result returns
-    /// into whatever frame the caller left on top (the handler frame for a
-    /// non-tail resume, or the prompt frame for a tail resume). One-shot: errors
-    /// if `k` was already resumed.
-    fn resume_continuation(&mut self, k: Val, v: Val) -> Result<(), VmError> {
-        let (saved, func, block, ip, mut regs, captures, perform_dst) = match self.get_obj(k) {
-            Some(Obj::Continuation { used: true, .. }) => {
-                return Err(VmError::new(VmErrorKind::ContinuationUsed)
-                    .with_span(self.current_span));
-            }
-            Some(Obj::Continuation {
-                saved,
-                func,
-                block,
-                ip,
-                regs,
-                captures,
-                perform_dst,
-                used: false,
-            }) => (
-                saved.clone(),
-                *func,
-                *block,
-                *ip,
-                regs.clone(),
-                captures.clone(),
-                *perform_dst,
-            ),
-            _ => {
-                return Err(VmError::new(VmErrorKind::NotCallable).with_span(self.current_span));
-            }
-        };
+    /// the captured frame segment and continue at the perform point with `v`
+    /// plugged in. One-shot: errors if `k` was already resumed.
+    ///
+    /// `base` distinguishes how the continuation's result is delivered:
+    /// - `Some(dst)` (non-tail resume): push the current (handler) frame as a
+    ///   fresh prompt returning into `dst`, and re-establish the handle's
+    ///   handlers at that prompt. This makes the continuation self-contained, so
+    ///   it works even when resumed after its original `handle` has exited (an
+    ///   escaping continuation, e.g. the function-passing `State`).
+    /// - `None` (tail resume): leave the frame already on top as the return
+    ///   target (the reader's non-escaping tail-resume path).
+    fn resume_continuation(&mut self, k: Val, v: Val, base: Option<u32>) -> Result<(), VmError> {
+        let (saved, func, block, ip, mut regs, captures, perform_dst, prompt_handlers) =
+            match self.get_obj(k) {
+                Some(Obj::Continuation { used: true, .. }) => {
+                    return Err(VmError::new(VmErrorKind::ContinuationUsed)
+                        .with_span(self.current_span));
+                }
+                Some(Obj::Continuation {
+                    saved,
+                    func,
+                    block,
+                    ip,
+                    regs,
+                    captures,
+                    perform_dst,
+                    prompt_handlers,
+                    used: false,
+                }) => (
+                    saved.clone(),
+                    *func,
+                    *block,
+                    *ip,
+                    regs.clone(),
+                    captures.clone(),
+                    *perform_dst,
+                    prompt_handlers.clone(),
+                ),
+                _ => {
+                    return Err(
+                        VmError::new(VmErrorKind::NotCallable).with_span(self.current_span)
+                    );
+                }
+            };
         if let Some(Obj::Continuation { used, .. }) = self.heap.get_mut(k.as_ptr()) {
             *used = true;
+        }
+        if let Some(dst) = base {
+            // Push the handler frame as a fresh prompt and re-establish the
+            // handle's handlers at it, so performs inside the resumed segment
+            // are handled (even though the original `handle` may be gone).
+            self.frames.push(Frame {
+                func: self.func,
+                block: self.block,
+                ip: self.ip,
+                regs: std::mem::take(&mut self.regs),
+                ret_reg: dst,
+                captures: std::mem::take(&mut self.captures),
+            });
+            let prompt = self.frames.len() - 1;
+            for h in prompt_handlers {
+                self.handlers.push(DynHandler {
+                    prompt_depth: prompt,
+                    ..h
+                });
+            }
         }
         for f in saved {
             self.frames.push(f);
@@ -623,7 +658,7 @@ impl Vm {
                         // the resumed body's result returns into the frame already
                         // below it (the prompt frame) — don't push a frame.
                         let v = vals.first().copied().unwrap_or(Val::UNIT);
-                        self.resume_continuation(func_val, v)?;
+                        self.resume_continuation(func_val, v, None)?;
                     } else if let Some(Obj::Closure(fid, caps)) = self.get_obj(func_val).cloned() {
                         let f = &module.funcs[fid.0 as usize];
                         let reg_count = f
@@ -746,18 +781,11 @@ impl Vm {
                 let vals = self.read_regs(args);
                 if matches!(self.get_obj(func_val), Some(Obj::Continuation { .. })) {
                     // Resume a continuation (e.g. `[resume v]` not in tail
-                    // position). Push the current (handler) frame so the
-                    // resumed body's result returns here into `dst`.
+                    // position). resume_continuation pushes the handler frame as
+                    // a fresh prompt (returning into `dst`) and re-establishes
+                    // the handlers, so the continuation is self-contained.
                     let v = vals.first().copied().unwrap_or(Val::UNIT);
-                    self.frames.push(Frame {
-                        func: self.func,
-                        block: self.block,
-                        ip: self.ip,
-                        regs: std::mem::take(&mut self.regs),
-                        ret_reg: dst.0,
-                        captures: std::mem::take(&mut self.captures),
-                    });
-                    self.resume_continuation(func_val, v)?;
+                    self.resume_continuation(func_val, v, Some(dst.0))?;
                 } else if let Some(Obj::Closure(fid, caps)) = self.get_obj(func_val).cloned() {
                     let ret_reg = dst.0;
                     self.call_func_with_captures(fid, &vals, ret_reg, caps)?;
@@ -859,7 +887,15 @@ impl Vm {
                 if let Some((hval, prompt_depth)) = found {
                     // Capture the continuation: every frame above the prompt,
                     // plus the current execution point (already advanced past
-                    // this perform), as a one-shot Obj::Continuation.
+                    // this perform), as a one-shot Obj::Continuation. Snapshot
+                    // this handle's handlers too, so the continuation can
+                    // re-establish them if resumed after the handle exits.
+                    let prompt_handlers: Vec<DynHandler> = self
+                        .handlers
+                        .iter()
+                        .filter(|h| h.prompt_depth == prompt_depth)
+                        .cloned()
+                        .collect();
                     let saved: Vec<Frame> = self.frames.split_off(prompt_depth + 1);
                     let cont = Obj::Continuation {
                         saved,
@@ -869,6 +905,7 @@ impl Vm {
                         regs: std::mem::take(&mut self.regs),
                         captures: std::mem::take(&mut self.captures),
                         perform_dst: dst.0,
+                        prompt_handlers,
                         used: false,
                     };
                     let k = self.alloc(cont);
@@ -2283,6 +2320,34 @@ mod tests {
              [handle [d 5] [E.op v] [+ [resume v] [resume v]]]",
         );
         assert!(r.is_err(), "expected one-shot violation");
+    }
+
+    #[test]
+    fn vm_effect_state_escaping() {
+        // A pure `State` effect via the function-passing encoding: the handlers
+        // return functions and the continuation is resumed AFTER the `handle`
+        // has exited (an escaping continuation). Threads state through get/put.
+        let rs = "[effect State [get [] Int] [put [Int] Unit]] \
+                  [fn run-state [t init] \
+                    [[handle [t] \
+                        [return x]    [fn [s] x] \
+                        [State.get]   [fn [s] [[resume s] s]] \
+                        [State.put n] [fn [s] [[resume 0] n]]] \
+                      init]] ";
+        // get; +1; get; +10; get  threaded from 0 -> 11
+        let counter = format!(
+            "{rs} [fn counter [] [let a [State.get]] [State.put [+ a 1]] \
+             [let b [State.get]] [State.put [+ b 10]] [State.get]] \
+             [run-state counter 0]"
+        );
+        assert_eq!(run(&counter).as_int(), 11);
+        // A recursive stateful loop summing 1..5.
+        let loopsum = format!(
+            "{rs} [fn lp [i] [if [> i 5] [State.get] \
+             [do [State.put [+ [State.get] i]] [lp [+ i 1]]]]] \
+             [fn c [] [lp 1]] [run-state c 0]"
+        );
+        assert_eq!(run(&loopsum).as_int(), 15);
     }
 
     #[test]

--- a/docs/elegance-notes.md
+++ b/docs/elegance-notes.md
@@ -93,26 +93,25 @@ Legend: **break?** = backward-incompatible · **effort** S/M/L.
    concatenation) would let the compiler be organized into actual modules.
    _break? no · effort L · **highest structural impact**_
 
-10. **⚙ PARTIAL — effect handlers were tail-resumptive only.** `resume` was an
-    identity closure and the handler's return was spliced at the perform site,
-    so there was no real abort and no resume-after-work. Now (EIR VM): `handle`
-    delimits a prompt (body lowered as a thunk), `perform` captures the frame
-    segment above the prompt as a one-shot `Obj::Continuation`, and the handler
-    runs there with `resume := k`. This gives **real abort (0-shot → `try`
-    works, was returning the wrong value)** and **resume-anywhere (1-shot, not
-    just tail)**, one-shot enforced. Still TODO: **escaping continuations** (a
-    continuation resumed *after* its `handle` has exited — needed for the
-    function-passing `State` encoding and multi-shot); that needs a relocatable,
-    self-contained continuation that re-establishes its prompt + handlers on
-    resume (OCaml-5 fiber style), rather than the in-place frame-segment capture.
-    A `Gensym`/`State`/`Ref` effect (#11) waits on that. _effort: L remaining_
+10. **✅ FIXED — one-shot delimited continuations (incl. escaping).** `resume`
+    was an identity closure (tail-resumptive only — no abort, no
+    resume-after-work). Now (EIR VM): `handle` delimits a prompt (body lowered
+    as a thunk), `perform` captures the frame segment above the prompt as a
+    one-shot `Obj::Continuation` that also **snapshots the prompt's handlers**.
+    This gives **real abort** (`try` works — was returning the wrong value),
+    **resume-anywhere** (not just tail), and — because a non-tail resume pushes a
+    fresh prompt and re-establishes those handlers — **escaping continuations**:
+    a continuation resumed *after* its `handle` has exited. That makes the pure
+    function-passing **`State` effect** work (see `samples/state.oo`). One-shot is
+    enforced; true multi-shot (clone-on-resume) is the only remaining tier, with
+    the documented mutation-soundness caveat.
 
-11. **No ergonomic local mutation — but we have effects!** Every pass threads
+11. **Ergonomic local mutation via effects — now unblocked.** Every pass threads
     state by hand (reader counters, the type `Subst`, the lowering builder `LS`).
-    This is inherent to purity, but a built-in `State`/`Ref` **effect** (handled
-    by the VM) would let passes use mutable cells while staying pure-by-default —
-    dogfooding the effect system. Depends on #10 for multi-shot. _break? no ·
-    effort M (after #10)_
+    With escaping continuations landed (#10), a pure `State`/`Ref` effect is now
+    expressible (`samples/state.oo` demonstrates it). Remaining work is purely
+    ergonomic: ship `State`/`Ref` as a small prelude/stdlib so passes can use it
+    without re-deriving the handler each time. _break? no · effort S now_
 
 ## D. Self-hosted compiler ergonomics
 

--- a/samples/state.oo
+++ b/samples/state.oo
@@ -1,0 +1,32 @@
+; A pure `State` effect, built entirely from one-shot delimited continuations
+; (no mutable cells). Each handler clause returns a function of the current
+; state; `run-state` applies the whole thing to the initial state. This relies
+; on escaping continuations — the continuation is resumed after `handle` exits.
+
+[effect State [get [] Int] [put [Int] Unit]]
+
+[fn run-state [thunk init]
+  [[handle [thunk]
+      [return x]    [fn [s] x]
+      [State.get]   [fn [s] [[resume s] s]]
+      [State.put n] [fn [s] [[resume 0] n]]]
+    init]]
+
+; A stateful counter: read, bump by 1, read, bump by 10, read.
+[fn counter []
+  [let a [State.get]]
+  [State.put [+ a 1]]
+  [let b [State.get]]
+  [State.put [+ b 10]]
+  [State.get]]
+
+; A recursive loop that sums 1..n into the state.
+[fn sum-loop [i n]
+  [if [> i n]
+    [State.get]
+    [do [State.put [+ [State.get] i]]
+        [sum-loop [+ i 1] n]]]]
+
+[fn main []
+  [println [run-state counter 0]]
+  [println [run-state [fn [] [sum-loop 1 10]] 0]]]


### PR DESCRIPTION
Completes the goal from a few PRs back: **a real `State` effect**. The blocker was *escaping continuations* — a continuation resumed **after** its `handle` has already exited. This PR makes the captured continuation self-contained so that works.

## Why it was hard
The pure function-passing `State` encoding has each handler clause *return a function* and resumes the continuation **later, when that function is applied** — by which point the `handle` has exited (its prompt frame gone, its handlers popped). The previous one-shot continuations only supported resuming *during* the handler (in-place frame-segment capture).

## The change
Two additions make a captured continuation **self-contained**:
1. `Obj::Continuation` now **snapshots the prompt's handlers** (those the `handle` installed) at capture time.
2. A **non-tail resume** pushes the handler frame as a **fresh prompt** (returning into the resume call's `dst`) and **re-establishes those handlers** at that prompt depth.

So performs inside a resumed continuation are still handled even though the original `handle` is gone, and they capture against a valid prompt. Tail resume is untouched (the reader's non-escaping path).

## It works
`samples/state.oo` — a pure `State` (get/put, **no mutable cells**, built entirely from handlers):
```
counter (get;+1;get;+10;get) from 0   => 11
recursive loop summing 1..10          => 55
```
And the earlier wins hold: `abort => 999`, `resume-anywhere => 1105`, and the reader's tail-resumptive handlers still pass F2.

## Effect capability ladder — now
- ✅ tail-resumptive · ✅ abort (0-shot, `try`) · ✅ resume-anywhere (1-shot) · ✅ **escaping continuations → pure `State`**
- ⏸ only **true multi-shot** (clone-on-resume) remains — with the documented mutation-soundness caveat.

## Tests / regressions
- New `vm_effect_state_escaping` (counter + recursive stateful loop).
- Full `loon-lang` + `loon-cli` suites pass; **all self-hosted gates green** (eir/f2/expand-vm/infer-vm/own-vm/check/own).

Elegance notes #10 (continuations) and #11 (`State`) updated — #11's remaining work is now just shipping `State`/`Ref` in a prelude.

https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus)_