### PR TITLE
Add WASM codegen for maps, CPS transform for escaping handlers

### DIFF
--- a/crates/loon-lang/src/codegen/cps.rs
+++ b/crates/loon-lang/src/codegen/cps.rs
@@ -1,0 +1,535 @@
+//! Source-to-source CPS + handler-passing transform for *escaping* effect
+//! handlers (the tier where a handler clause returns a function — e.g. the
+//! pure `State` effect in `samples/state.oo`). The tail-resumptive and abort
+//! tiers are handled directly in the backend; this pass only fires when an
+//! escaping handle is present (`needs_cps`), so it can't affect other programs.
+//!
+//! It rewrites the program into ordinary Loon (closures + first-class calls,
+//! which the backend already compiles), threading two extra arguments through
+//! every effectful function:
+//!   - `k`: the delimited continuation — a plain function `opresult -> answer`,
+//!   - `h`: the handler dispatcher — `(op_tag, arg, resume) -> answer`.
+//! An "answer" is whatever the handler clauses produce (for State, a function
+//! `state -> result`). Effect operations consume the current continuation as
+//! `resume` and invoke `h`; `handle` builds `h`/`return` from its clauses and
+//! runs the delimited body. Continuations are ordinary closures, so they may be
+//! invoked zero, one, or many times (multi-shot).
+
+use crate::ast::{Expr, ExprKind};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static GENSYM: AtomicU32 = AtomicU32::new(0);
+
+fn gensym(prefix: &str) -> String {
+    let n = GENSYM.fetch_add(1, Ordering::Relaxed);
+    format!("__cps_{prefix}{n}")
+}
+
+fn sym(s: &str) -> Expr {
+    Expr::new(ExprKind::Symbol(s.to_string()), crate::syntax::Span::ZERO)
+}
+fn int(n: i64) -> Expr {
+    Expr::new(ExprKind::Int(n), crate::syntax::Span::ZERO)
+}
+fn list(items: Vec<Expr>) -> Expr {
+    Expr::new(ExprKind::List(items), crate::syntax::Span::ZERO)
+}
+/// `[do [let name val] body]` — bind `name` to `val`, then evaluate `body`.
+/// (Loon's `let` is a statement; a bare `[let n v body]` would drop `body`.)
+fn let_in(name: &str, val: Expr, body: Expr) -> Expr {
+    list(vec![
+        sym("do"),
+        list(vec![sym("let"), sym(name), val]),
+        body,
+    ])
+}
+/// `[fn [params...] body...]`
+fn lam(params: Vec<&str>, body: Vec<Expr>) -> Expr {
+    let mut v = vec![sym("fn")];
+    v.push(list(params.into_iter().map(sym).collect()));
+    v.extend(body);
+    list(v)
+}
+
+/// Is this a `[head ...]` form?
+fn head_is(e: &Expr, name: &str) -> bool {
+    matches!(&e.kind, ExprKind::List(items)
+        if matches!(items.first().map(|x| &x.kind), Some(ExprKind::Symbol(s)) if s == name))
+}
+
+/// Whether the program contains an *escaping* handle (a handler clause whose
+/// body is a `[fn …]`), which is what this transform handles.
+pub fn needs_cps(exprs: &[Expr]) -> bool {
+    fn walk(e: &Expr) -> bool {
+        if let ExprKind::List(items) = &e.kind {
+            if head_is(e, "handle") {
+                // clauses are items[2..], in (pattern, body) pairs
+                let mut i = 2;
+                while i + 1 < items.len() {
+                    if head_is(&items[i + 1], "fn") {
+                        return true;
+                    }
+                    i += 2;
+                }
+            }
+            return items.iter().any(walk);
+        }
+        false
+    }
+    exprs.iter().any(walk)
+}
+
+/// A delimited continuation under construction.
+enum Cont<'a> {
+    /// A variable already bound to a continuation closure.
+    Var(String),
+    /// An inlined continuation: given the result expression, build the rest.
+    Fn(Box<dyn FnOnce(Expr) -> Expr + 'a>),
+}
+
+struct Cps {
+    /// "Effect.op" -> small integer tag, shared between op sites and handlers.
+    op_tags: HashMap<String, i64>,
+}
+
+impl Cps {
+    fn op_tag(&mut self, key: &str) -> i64 {
+        let n = self.op_tags.len() as i64;
+        *self.op_tags.entry(key.to_string()).or_insert(n)
+    }
+
+    /// Apply a continuation to a (pure) value expression.
+    fn apply(cont: Cont, value: Expr) -> Expr {
+        match cont {
+            Cont::Var(k) => list(vec![sym(&k), value]),
+            Cont::Fn(f) => f(value),
+        }
+    }
+
+    /// Materialize a continuation as a closure value `[fn [x] …]`.
+    fn reify(self_cps: &mut Cps, cont: Cont, h: &str) -> Expr {
+        match cont {
+            Cont::Var(k) => sym(&k),
+            Cont::Fn(_) => {
+                let x = gensym("v");
+                let body = Self::apply(cont, sym(&x));
+                let _ = (self_cps, h);
+                lam(vec![&x], vec![body])
+            }
+        }
+    }
+
+    /// CPS-transform expression `e` with continuation `cont` and handler var `h`.
+    fn t(&mut self, e: &Expr, cont: Cont, h: &str) -> Expr {
+        match &e.kind {
+            ExprKind::Int(_)
+            | ExprKind::Float(_)
+            | ExprKind::Bool(_)
+            | ExprKind::Str(_)
+            | ExprKind::Keyword(_)
+            | ExprKind::Symbol(_) => Self::apply(cont, e.clone()),
+
+            ExprKind::List(items) if items.is_empty() => Self::apply(cont, e.clone()),
+
+            ExprKind::List(items) => {
+                let head = &items[0];
+                if let ExprKind::Symbol(s) = &head.kind {
+                    match s.as_str() {
+                        "fn" => {
+                            // A lambda value: CPS its body; it gains (k, h).
+                            return Self::apply(cont, self.t_fn(items));
+                        }
+                        "let" => {
+                            // [let x e1] is a statement; the rest follows in the
+                            // enclosing sequence — handled by t_seq. A bare let
+                            // here just binds for the continuation value.
+                            // (Sequences route through t_seq, so this is rare.)
+                            return self.t_seq(std::slice::from_ref(e), cont, h);
+                        }
+                        "do" => {
+                            return self.t_seq(&items[1..], cont, h);
+                        }
+                        "if" => {
+                            let c = &items[1];
+                            let then_e = &items[2];
+                            let else_e = items.get(3).cloned().unwrap_or_else(|| int(0));
+                            // Reify the continuation once (used by both arms).
+                            let kname = gensym("k");
+                            let kval = Self::reify(self, cont, h);
+                            let then_c = self.t(then_e, Cont::Var(kname.clone()), h);
+                            let else_c = self.t(&else_e, Cont::Var(kname.clone()), h);
+                            let cv = gensym("c");
+                            let inner = list(vec![sym("if"), sym(&cv), then_c, else_c]);
+                            let cond_cont = Cont::Fn(Box::new(move |cval: Expr| {
+                                let_in(&cv, cval, inner)
+                            }));
+                            // wrap: [let kname kval] <cond>
+                            let body = self.t(c, cond_cont, h);
+                            return let_in(&kname, kval, body);
+                        }
+                        "handle" => {
+                            return self.t_handle(items, cont, h);
+                        }
+                        "resume" => {
+                            // In computation land resume shouldn't appear; clause
+                            // bodies are emitted verbatim. Treat as a value call.
+                        }
+                        _ => {}
+                    }
+                    // Effect operation: Effect.op via DotAccess head is below;
+                    // a bare-symbol head is a function/builtin call.
+                }
+                // DotAccess head => effect operation.
+                if let ExprKind::DotAccess(obj, op) = &head.kind {
+                    if let ExprKind::Symbol(effect) = &obj.kind {
+                        if effect.starts_with(char::is_uppercase) {
+                            return self.t_effect(effect, op, &items[1..], cont, h);
+                        }
+                    }
+                }
+                // Otherwise: an application. CPS the args, then call.
+                self.t_app(items, cont, h)
+            }
+
+            _ => Self::apply(cont, e.clone()),
+        }
+    }
+
+    /// CPS a `[fn [params] body…]` lambda value: it takes the original params
+    /// plus a continuation `k` and handler `h`.
+    fn t_fn(&mut self, items: &[Expr]) -> Expr {
+        let params = match items.get(1).map(|e| &e.kind) {
+            Some(ExprKind::List(p)) => p.clone(),
+            _ => Vec::new(),
+        };
+        let k = gensym("k");
+        let h = gensym("h");
+        let body = self.t_seq(&items[2..], Cont::Var(k.clone()), &h);
+        let mut all: Vec<Expr> = params;
+        all.push(sym(&k));
+        all.push(sym(&h));
+        list(vec![sym("fn"), list(all), body])
+    }
+
+    /// CPS a statement sequence (function body / do): `let`s scope to the rest.
+    fn t_seq(&mut self, stmts: &[Expr], cont: Cont, h: &str) -> Expr {
+        if stmts.is_empty() {
+            return Self::apply(cont, int(0));
+        }
+        if stmts.len() == 1 {
+            return self.t(&stmts[0], cont, h);
+        }
+        let first = &stmts[0];
+        let rest = &stmts[1..];
+        // [let x e1] rest...  => CPS e1 with cont (fn [x] CPS[rest])
+        if head_is(first, "let") {
+            if let ExprKind::List(li) = &first.kind {
+                // [let x v] or [let mut x v]
+                let (ni, vi) = if matches!(li.get(1).map(|e| &e.kind), Some(ExprKind::Symbol(s)) if s == "mut")
+                {
+                    (2, 3)
+                } else {
+                    (1, 2)
+                };
+                let name = match li.get(ni).map(|e| &e.kind) {
+                    Some(ExprKind::Symbol(s)) => s.clone(),
+                    _ => gensym("ignored"),
+                };
+                let val = li[vi].clone();
+                // Bind the rest under `let name = <result of val>`.
+                let bound = self.t_seq(rest, cont, h);
+                let rest_cont = move |xval: Expr| -> Expr { let_in(&name, xval, bound) };
+                return self.t(&val, Cont::Fn(Box::new(rest_cont)), h);
+            }
+        }
+        // Non-let statement: evaluate it (for effect), then the rest. The value
+        // is sequenced via `do` so side effects aren't dropped.
+        let bound = self.t_seq(rest, cont, h);
+        let drop_cont = move |v: Expr| -> Expr { list(vec![sym("do"), v, bound]) };
+        self.t(first, Cont::Fn(Box::new(drop_cont)), h)
+    }
+
+    /// CPS an effect operation `Effect.op args…`: the continuation becomes
+    /// `resume`, and we invoke the dispatcher `h` with (tag, arg, resume).
+    fn t_effect(&mut self, effect: &str, op: &str, args: &[Expr], cont: Cont, h: &str) -> Expr {
+        let tag = self.op_tag(&format!("{effect}.{op}"));
+        let resume = Self::reify(self, cont, h);
+        // One-argument ops (get: none, put: one). Evaluate the arg purely first.
+        if args.is_empty() {
+            list(vec![sym(h), int(tag), int(0), resume])
+        } else {
+            // Evaluate arg with a continuation that performs the op.
+            let h_owned = h.to_string();
+            let arg_cont = move |av: Expr| -> Expr {
+                list(vec![sym(&h_owned), int(tag), av, resume])
+            };
+            self.t(&args[0], Cont::Fn(Box::new(arg_cont)), h)
+        }
+    }
+
+    /// CPS an application `[f args…]`. Evaluates `f` and each arg to atoms, then
+    /// either calls a user/CPS function (passing the continuation + handler) or
+    /// applies a pure builtin and feeds the result to the continuation.
+    fn t_app(&mut self, items: &[Expr], cont: Cont, h: &str) -> Expr {
+        let head = items[0].clone();
+        // A "direct" call feeds its result straight to the continuation (no
+        // resume/handler threading): pure builtins, and applications of a
+        // *computed* value-function — e.g. `[[handle …] init]` applies the
+        // handler's answer (a plain `state -> result`), and a continuation
+        // applied to a value. A bare-symbol head names a CPS function (user fn
+        // or thunk param), which takes the continuation + handler.
+        let pure_builtin = matches!(&head.kind, ExprKind::Symbol(s) if is_pure_builtin(s))
+            || !matches!(&head.kind, ExprKind::Symbol(_));
+        // Evaluate all sub-expressions (head + args) to temporaries, innermost
+        // continuation builds the actual call.
+        let mut atoms: Vec<Expr> = Vec::new();
+        self.t_app_args(&head, items, 0, &mut atoms, cont, h, pure_builtin)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn t_app_args(
+        &mut self,
+        head: &Expr,
+        items: &[Expr],
+        idx: usize,
+        atoms: &mut Vec<Expr>,
+        cont: Cont,
+        h: &str,
+        pure_builtin: bool,
+    ) -> Expr {
+        if idx == items.len() {
+            // All evaluated: build the call.
+            if pure_builtin {
+                let call = list(atoms.clone());
+                return Self::apply(cont, call);
+            }
+            // User function (or computed head): pass continuation + handler.
+            let resume = Self::reify(self, cont, h);
+            let mut call = atoms.clone();
+            call.push(resume);
+            call.push(sym(h));
+            return list(call);
+        }
+        // Evaluate items[idx] to a temp, recurse.
+        let cur = items[idx].clone();
+        if is_atom(&cur) {
+            atoms.push(cur);
+            // can't recurse with atoms borrowed in closure; do it directly
+            return self.t_app_args(head, items, idx + 1, atoms, cont, h, pure_builtin);
+        }
+        let tmp = gensym("a");
+        // Build the rest after binding tmp.
+        let mut atoms_after = atoms.clone();
+        atoms_after.push(sym(&tmp));
+        let rest = self.t_app_args_owned(
+            head.clone(),
+            items.to_vec(),
+            idx + 1,
+            atoms_after,
+            cont,
+            h.to_string(),
+            pure_builtin,
+        );
+        let bind = move |val: Expr| -> Expr { let_in(&tmp, val, rest) };
+        self.t(&cur, Cont::Fn(Box::new(bind)), h)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn t_app_args_owned(
+        &mut self,
+        head: Expr,
+        items: Vec<Expr>,
+        idx: usize,
+        mut atoms: Vec<Expr>,
+        cont: Cont,
+        h: String,
+        pure_builtin: bool,
+    ) -> Expr {
+        let _ = &head;
+        self.t_app_args(&head.clone(), &items, idx, &mut atoms, cont, &h, pure_builtin)
+    }
+
+    /// CPS `[handle bodyexpr (pat hbody)…]`: build the dispatcher and return
+    /// continuation from the clauses, then run the delimited body with them.
+    fn t_handle(&mut self, items: &[Expr], cont: Cont, h_outer: &str) -> Expr {
+        let body = &items[1];
+        // Parse clauses.
+        let mut ret_param: Option<String> = None;
+        let mut ret_body: Option<Expr> = None;
+        // dispatcher arms: (tag, op_param: Option<String>, clause_body Expr)
+        let mut arms: Vec<(i64, Option<String>, Expr)> = Vec::new();
+        let mut i = 2;
+        while i + 1 < items.len() {
+            let pat = &items[i];
+            let hbody = &items[i + 1];
+            i += 2;
+            let parts = match &pat.kind {
+                ExprKind::List(p) if !p.is_empty() => p,
+                _ => continue,
+            };
+            if let ExprKind::Symbol(s) = &parts[0].kind {
+                if s == "return" {
+                    if let Some(ExprKind::Symbol(x)) = parts.get(1).map(|e| &e.kind) {
+                        ret_param = Some(x.clone());
+                        ret_body = Some(hbody.clone());
+                    }
+                    continue;
+                }
+            }
+            if let ExprKind::DotAccess(obj, op) = &parts[0].kind {
+                if let ExprKind::Symbol(effect) = &obj.kind {
+                    let tag = self.op_tag(&format!("{effect}.{op}"));
+                    let op_param = match parts.get(1).map(|e| &e.kind) {
+                        Some(ExprKind::Symbol(s)) => Some(s.clone()),
+                        _ => None,
+                    };
+                    arms.push((tag, op_param, hbody.clone()));
+                }
+            }
+        }
+        // Dispatcher: [fn [op arg resume] (if [= op t0] body0 (if ... 0))].
+        // `resume` is renamed away from the reserved word the backend uses for
+        // tail-resumptive handlers (it would otherwise be treated as identity).
+        let op_v = "__op";
+        let arg_v = "__arg";
+        let resume_v = "__cps_resume";
+        let mut dispatch = int(0);
+        for (tag, op_param, clause_body) in arms.into_iter().rev() {
+            // Rename `resume` -> resume_v and the op-param -> __arg in the body.
+            let cb0 = subst(&clause_body, "resume", &sym(resume_v));
+            let cb = match op_param {
+                Some(p) => subst(&cb0, &p, &sym(arg_v)),
+                None => cb0,
+            };
+            dispatch = list(vec![
+                sym("if"),
+                list(vec![sym("="), sym(op_v), int(tag)]),
+                cb,
+                dispatch,
+            ]);
+        }
+        let h_name = gensym("h");
+        let dispatcher = lam(vec![op_v, arg_v, resume_v], vec![dispatch]);
+        // return continuation: [fn [x] ret_body]
+        let ret_lam = match (ret_param, ret_body) {
+            (Some(x), Some(rb)) => lam(vec![&x], vec![rb]),
+            _ => {
+                let x = gensym("x");
+                lam(vec![&x], vec![sym(&x)])
+            }
+        };
+        let ret_name = gensym("ret");
+        // Delimited body run with (ret, h_name): CPS the handle body.
+        let answer = self.t(body, Cont::Var(ret_name.clone()), &h_name);
+        // [let h_name dispatcher] [let ret_name ret_lam] (apply cont answer)
+        let _ = h_outer;
+        let final_expr = Self::apply(cont, answer);
+        let_in(&h_name, dispatcher, let_in(&ret_name, ret_lam, final_expr))
+    }
+
+    /// Transform a top-level `[fn name [params] body…]` into CPS form.
+    fn t_defn(&mut self, items: &[Expr]) -> Expr {
+        // items = [name, [params], body...]
+        let name = items[0].clone();
+        let params = match items.get(1).map(|e| &e.kind) {
+            Some(ExprKind::List(p)) => p.clone(),
+            _ => Vec::new(),
+        };
+        let k = gensym("k");
+        let h = gensym("h");
+        let body = self.t_seq(&items[2..], Cont::Var(k.clone()), &h);
+        let mut all = params;
+        all.push(sym(&k));
+        all.push(sym(&h));
+        list(vec![sym("fn"), name, list(all), body])
+    }
+
+    /// Transform `main`: run its body with a top-level identity continuation and
+    /// a dummy handler (effects only occur inside `run-state`-style calls, which
+    /// install their own handlers).
+    fn t_main(&mut self, items: &[Expr]) -> Expr {
+        let name = items[0].clone();
+        let kid = gensym("k");
+        let h = gensym("h");
+        // identity continuation [fn [x] x]
+        let body = self.t_seq(&items[2..], Cont::Var(kid.clone()), &h);
+        let wrapped = let_in(&kid, lam(vec!["x"], vec![sym("x")]), let_in(&h, int(0), body));
+        list(vec![sym("fn"), name, list(vec![]), wrapped])
+    }
+}
+
+/// Pure builtins whose application is value-land (fed straight to the cont).
+fn is_pure_builtin(s: &str) -> bool {
+    matches!(
+        s,
+        "+" | "-" | "*" | "/" | "%" | "mod" | "=" | "!=" | "<" | ">" | "<=" | ">="
+            | "not" | "and" | "or" | "inc" | "dec" | "abs" | "min" | "max"
+            | "str" | "str-concat" | "println" | "print"
+    )
+}
+
+fn is_atom(e: &Expr) -> bool {
+    matches!(
+        e.kind,
+        ExprKind::Int(_)
+            | ExprKind::Float(_)
+            | ExprKind::Bool(_)
+            | ExprKind::Str(_)
+            | ExprKind::Keyword(_)
+            | ExprKind::Symbol(_)
+    )
+}
+
+/// Capture-free-ish substitution of a symbol `name` with `repl` (used only for
+/// renaming an op parameter to the dispatcher's `arg`, which is hygienic here).
+fn subst(e: &Expr, name: &str, repl: &Expr) -> Expr {
+    match &e.kind {
+        ExprKind::Symbol(s) if s == name => repl.clone(),
+        ExprKind::List(items) => Expr::new(
+            ExprKind::List(items.iter().map(|x| subst(x, name, repl)).collect()),
+            e.span,
+        ),
+        ExprKind::Vec(items) => Expr::new(
+            ExprKind::Vec(items.iter().map(|x| subst(x, name, repl)).collect()),
+            e.span,
+        ),
+        ExprKind::Tuple(items) => Expr::new(
+            ExprKind::Tuple(items.iter().map(|x| subst(x, name, repl)).collect()),
+            e.span,
+        ),
+        _ => e.clone(),
+    }
+}
+
+/// Transform a whole program, CPS-converting function definitions (and `main`).
+/// `[effect …]` declarations are dropped (effect ops are gone after the pass).
+pub fn transform(exprs: &[Expr]) -> Vec<Expr> {
+    let mut cps = Cps {
+        op_tags: HashMap::new(),
+    };
+    let mut out = Vec::new();
+    for e in exprs {
+        if let ExprKind::List(items) = &e.kind {
+            if let Some(ExprKind::Symbol(s)) = items.first().map(|x| &x.kind) {
+                if s == "effect" {
+                    continue; // no longer needed
+                }
+                if s == "fn" && items.len() >= 3 {
+                    let is_main = matches!(items.get(1).map(|x| &x.kind), Some(ExprKind::Symbol(n)) if n == "main");
+                    if is_main {
+                        out.push(cps.t_main(&items[1..]));
+                    } else if matches!(items.get(1).map(|x| &x.kind), Some(ExprKind::Symbol(_))) {
+                        out.push(cps.t_defn(&items[1..]));
+                    } else {
+                        out.push(e.clone());
+                    }
+                    continue;
+                }
+            }
+        }
+        out.push(e.clone());
+    }
+    out
+}
+

--- a/crates/loon-lang/src/codegen/maps.rs
+++ b/crates/loon-lang/src/codegen/maps.rs
@@ -27,6 +27,7 @@ pub struct MapRuntime {
     pub map_has_idx: u32,
     pub map_keys_idx: u32,
     pub map_entries_idx: u32,
+    pub map_merge_idx: u32,
 }
 
 impl MapRuntime {
@@ -495,6 +496,65 @@ impl MapRuntime {
             params: vec![ValType::I64],
             results: vec![ValType::I64],
             locals: vec![ValType::I64; 5],
+            instructions: i,
+        }
+    }
+
+    /// `map_merge(a, b, map_set) -> i64` — `a` with every entry of `b` inserted
+    /// on top (so `b` wins on conflicts), preserving order.
+    pub(super) fn gen_map_merge(map_set: u32) -> FunctionBody {
+        // Params: 0=a, 1=b ; Locals: 2=acc, 3=len, 4=data, 5=i
+        let mut i = Vec::new();
+        i.push(LocalGet(0));
+        i.push(LocalSet(2));
+        i.push(LocalGet(1));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalSet(3));
+        i.push(LocalGet(1));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 16));
+        i.push(LocalSet(4));
+        i.push(I64Const(0));
+        i.push(LocalSet(5));
+        i.push(Block(BlockType::Empty));
+        i.push(Loop(BlockType::Empty));
+        i.push(LocalGet(5));
+        i.push(LocalGet(3));
+        i.push(I64LtS);
+        i.push(I32Eqz);
+        i.push(BrIf(1));
+        // acc = map_set(acc, data[i*16], data[i*16+8], 0)
+        i.push(LocalGet(2));
+        i.push(LocalGet(4));
+        i.push(LocalGet(5));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalGet(4));
+        i.push(LocalGet(5));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 8));
+        i.push(I64Const(0));
+        i.push(Call(map_set));
+        i.push(LocalSet(2));
+        i.push(LocalGet(5));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(5));
+        i.push(Br(0));
+        i.push(End);
+        i.push(End);
+        i.push(LocalGet(2));
+        FunctionBody {
+            params: vec![ValType::I64, ValType::I64],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64; 4],
             instructions: i,
         }
     }

--- a/crates/loon-lang/src/codegen/maps.rs
+++ b/crates/loon-lang/src/codegen/maps.rs
@@ -26,6 +26,7 @@ pub struct MapRuntime {
     pub map_get_idx: u32,
     pub map_has_idx: u32,
     pub map_keys_idx: u32,
+    pub map_entries_idx: u32,
 }
 
 impl MapRuntime {
@@ -430,6 +431,70 @@ impl MapRuntime {
             params: vec![ValType::I64],
             results: vec![ValType::I64],
             locals: vec![ValType::I64, ValType::I64, ValType::I64, ValType::I64],
+            instructions: i,
+        }
+    }
+
+    /// `map_entries(m, vec_new, vec_push) -> i64` — a vector of `[k v]` pairs
+    /// (each pair is itself a two-element vector), in insertion order.
+    pub(super) fn gen_map_entries(vec_new: u32, vec_push: u32) -> FunctionBody {
+        // Params: 0=m ; Locals: 1=len,2=data,3=i,4=r,5=pair
+        let mut i = Vec::new();
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalSet(1));
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 16));
+        i.push(LocalSet(2));
+        i.push(Call(vec_new));
+        i.push(LocalSet(4));
+        i.push(I64Const(0));
+        i.push(LocalSet(3));
+        i.push(Block(BlockType::Empty));
+        i.push(Loop(BlockType::Empty));
+        i.push(LocalGet(3));
+        i.push(LocalGet(1));
+        i.push(I64LtS);
+        i.push(I32Eqz);
+        i.push(BrIf(1));
+        // pair = vec_push(vec_push(vec_new(), key), val)
+        i.push(Call(vec_new));
+        i.push(LocalGet(2));
+        i.push(LocalGet(3));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0)); // key
+        i.push(Call(vec_push));
+        i.push(LocalGet(2));
+        i.push(LocalGet(3));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 8)); // value
+        i.push(Call(vec_push));
+        i.push(LocalSet(5));
+        // r = vec_push(r, pair)
+        i.push(LocalGet(4));
+        i.push(LocalGet(5));
+        i.push(Call(vec_push));
+        i.push(LocalSet(4));
+        i.push(LocalGet(3));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(3));
+        i.push(Br(0));
+        i.push(End);
+        i.push(End);
+        i.push(LocalGet(4));
+        FunctionBody {
+            params: vec![ValType::I64],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64; 5],
             instructions: i,
         }
     }

--- a/crates/loon-lang/src/codegen/maps.rs
+++ b/crates/loon-lang/src/codegen/maps.rs
@@ -1,0 +1,410 @@
+//! Insertion-ordered maps for WASM codegen (simplified v0.5).
+//!
+//! A map is a heap structure mirroring the vector layout, but its data array
+//! holds interleaved `key, value` i64 pairs:
+//!
+//!   offset 0:  len      (i64) — number of entries
+//!   offset 8:  capacity (i64) — entry capacity
+//!   offset 16: data_ptr (i64) — points to `capacity * 2` i64 slots
+//!
+//! Operations are copy-on-write for persistence, like vectors. Key comparison
+//! is selected by an `is_str` flag passed from the call site (the compiler
+//! knows the static key type): string keys compare by content via `str_eq`,
+//! everything else by raw i64 equality. Uses global 0 as the bump allocator.
+
+use super::{FunctionBody, WasmInstruction::*};
+use wasm_encoder::*;
+
+/// Function indices of the map runtime helpers.
+#[derive(Clone, Debug)]
+pub struct MapRuntime {
+    pub map_new_idx: u32,
+    pub map_set_idx: u32,
+    pub map_get_idx: u32,
+    pub map_has_idx: u32,
+    pub map_keys_idx: u32,
+}
+
+impl MapRuntime {
+    /// `map_new() -> i64` — empty map (capacity 4 entries).
+    pub(super) fn gen_map_new() -> FunctionBody {
+        // Locals: 0 = header, 1 = data
+        let mut i = Vec::new();
+        i.push(GlobalGet(0));
+        i.push(I64ExtendI32U);
+        i.push(LocalSet(0));
+        i.push(GlobalGet(0));
+        i.push(I32Const(24));
+        i.push(I32Add);
+        i.push(GlobalSet(0));
+        // data: cap 4 entries -> 4*2 = 8 i64 = 64 bytes
+        i.push(GlobalGet(0));
+        i.push(I64ExtendI32U);
+        i.push(LocalSet(1));
+        i.push(GlobalGet(0));
+        i.push(I32Const(64));
+        i.push(I32Add);
+        i.push(GlobalSet(0));
+        // len = 0, cap = 4, data_ptr
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Const(0));
+        i.push(I64Store(3, 0));
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Const(4));
+        i.push(I64Store(3, 8));
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(LocalGet(1));
+        i.push(I64Store(3, 16));
+        i.push(LocalGet(0));
+        FunctionBody {
+            params: vec![],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64, ValType::I64],
+            instructions: i,
+        }
+    }
+
+    /// Emit: compute key equality of locals `a` and `b` (both i64) under the
+    /// `is_str` flag (local), leaving an i64 0/1 on the stack. Calls `str_eq`.
+    fn emit_key_eq(i: &mut Vec<super::WasmInstruction>, a: u32, b: u32, is_str: u32, str_eq: u32) {
+        i.push(LocalGet(is_str));
+        i.push(I64Eqz); // 1 if not string
+        i.push(If(BlockType::Result(ValType::I64)));
+        // non-string: a == b
+        i.push(LocalGet(a));
+        i.push(LocalGet(b));
+        i.push(I64Eq);
+        i.push(I64ExtendI32U);
+        i.push(Else);
+        // string: str_eq(a, b)
+        i.push(LocalGet(a));
+        i.push(LocalGet(b));
+        i.push(Call(str_eq));
+        i.push(End);
+    }
+
+    /// `map_get(m, k, is_str) -> v` — value for `k`, or 0 (UNIT) if absent.
+    pub(super) fn gen_map_get(str_eq: u32) -> FunctionBody {
+        // Params: 0=m, 1=k, 2=is_str
+        // Locals: 3=len, 4=data, 5=i, 6=ek
+        let mut i = Vec::new();
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalSet(3));
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 16));
+        i.push(LocalSet(4));
+        i.push(I64Const(0));
+        i.push(LocalSet(5));
+        i.push(Block(BlockType::Empty));
+        i.push(Loop(BlockType::Empty));
+        // if i >= len break
+        i.push(LocalGet(5));
+        i.push(LocalGet(3));
+        i.push(I64LtS);
+        i.push(I32Eqz);
+        i.push(BrIf(1));
+        // ek = data[i*16]
+        i.push(LocalGet(4));
+        i.push(LocalGet(5));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalSet(6));
+        // if key_eq(ek, k) return data[i*16+8]
+        Self::emit_key_eq(&mut i, 6, 1, 2, str_eq);
+        i.push(I64Eqz);
+        i.push(I32Eqz); // truthy?
+        i.push(If(BlockType::Empty));
+        i.push(LocalGet(4));
+        i.push(LocalGet(5));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 8));
+        i.push(Return);
+        i.push(End);
+        // i++
+        i.push(LocalGet(5));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(5));
+        i.push(Br(0));
+        i.push(End);
+        i.push(End);
+        i.push(I64Const(0));
+        FunctionBody {
+            params: vec![ValType::I64, ValType::I64, ValType::I64],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64, ValType::I64, ValType::I64, ValType::I64],
+            instructions: i,
+        }
+    }
+
+    /// `map_has(m, k, is_str) -> i64` — 1 if `k` present, else 0.
+    pub(super) fn gen_map_has(str_eq: u32) -> FunctionBody {
+        // Params: 0=m, 1=k, 2=is_str ; Locals: 3=len,4=data,5=i,6=ek
+        let mut i = Vec::new();
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalSet(3));
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 16));
+        i.push(LocalSet(4));
+        i.push(I64Const(0));
+        i.push(LocalSet(5));
+        i.push(Block(BlockType::Empty));
+        i.push(Loop(BlockType::Empty));
+        i.push(LocalGet(5));
+        i.push(LocalGet(3));
+        i.push(I64LtS);
+        i.push(I32Eqz);
+        i.push(BrIf(1));
+        i.push(LocalGet(4));
+        i.push(LocalGet(5));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalSet(6));
+        Self::emit_key_eq(&mut i, 6, 1, 2, str_eq);
+        i.push(I64Eqz);
+        i.push(I32Eqz);
+        i.push(If(BlockType::Empty));
+        i.push(I64Const(1));
+        i.push(Return);
+        i.push(End);
+        i.push(LocalGet(5));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(5));
+        i.push(Br(0));
+        i.push(End);
+        i.push(End);
+        i.push(I64Const(0));
+        FunctionBody {
+            params: vec![ValType::I64, ValType::I64, ValType::I64],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64, ValType::I64, ValType::I64, ValType::I64],
+            instructions: i,
+        }
+    }
+
+    /// `map_set(m, k, v, is_str) -> i64` — copy-on-write assoc. Replaces the
+    /// value if `k` exists (preserving order), else appends `k,v`.
+    pub(super) fn gen_map_set(str_eq: u32) -> FunctionBody {
+        // Params: 0=m,1=k,2=v,3=is_str
+        // Locals: 4=len,5=old_data,6=found,7=new_len,8=new_hdr,9=new_data,
+        //         10=i,11=ek
+        let mut i = Vec::new();
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalSet(4)); // len
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 16));
+        i.push(LocalSet(5)); // old_data
+        // found = 0
+        i.push(I64Const(0));
+        i.push(LocalSet(6));
+        // new_len = len + 1 (capacity); actual len fixed up after the copy
+        i.push(LocalGet(4));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(7));
+        // alloc header (24)
+        i.push(GlobalGet(0));
+        i.push(I64ExtendI32U);
+        i.push(LocalSet(8));
+        i.push(GlobalGet(0));
+        i.push(I32Const(24));
+        i.push(I32Add);
+        i.push(GlobalSet(0));
+        // alloc data: new_len * 16 bytes
+        i.push(GlobalGet(0));
+        i.push(I64ExtendI32U);
+        i.push(LocalSet(9));
+        i.push(GlobalGet(0));
+        i.push(LocalGet(7));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I32WrapI64);
+        i.push(I32Add);
+        i.push(GlobalSet(0));
+        // copy entries: for i in 0..len
+        i.push(I64Const(0));
+        i.push(LocalSet(10));
+        i.push(Block(BlockType::Empty));
+        i.push(Loop(BlockType::Empty));
+        i.push(LocalGet(10));
+        i.push(LocalGet(4));
+        i.push(I64LtS);
+        i.push(I32Eqz);
+        i.push(BrIf(1));
+        // ek = old_data[i*16]
+        i.push(LocalGet(5));
+        i.push(LocalGet(10));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalSet(11));
+        // new_data[i*16] = ek
+        i.push(LocalGet(9));
+        i.push(LocalGet(10));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(LocalGet(11));
+        i.push(I64Store(3, 0));
+        // value: if key_eq(ek,k) { v ; found=1 } else { old value }
+        Self::emit_key_eq(&mut i, 11, 1, 3, str_eq);
+        i.push(I64Eqz);
+        i.push(I32Eqz);
+        i.push(If(BlockType::Result(ValType::I64)));
+        i.push(I64Const(1));
+        i.push(LocalSet(6)); // found = 1
+        i.push(LocalGet(2)); // v
+        i.push(Else);
+        i.push(LocalGet(5));
+        i.push(LocalGet(10));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 8));
+        i.push(End);
+        // store the chosen value at new_data[i*16+8]
+        i.push(LocalSet(11)); // reuse ek slot as scratch for the value
+        i.push(LocalGet(9));
+        i.push(LocalGet(10));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(LocalGet(11));
+        i.push(I64Store(3, 8));
+        // i++
+        i.push(LocalGet(10));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(10));
+        i.push(Br(0));
+        i.push(End);
+        i.push(End);
+        // if !found: append k,v at slot `len`; final len = len+1; else len
+        i.push(LocalGet(6));
+        i.push(I64Eqz); // 1 if not found
+        i.push(If(BlockType::Empty));
+        // new_data[len*16] = k
+        i.push(LocalGet(9));
+        i.push(LocalGet(4));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(LocalGet(1));
+        i.push(I64Store(3, 0));
+        // new_data[len*16+8] = v
+        i.push(LocalGet(9));
+        i.push(LocalGet(4));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(LocalGet(2));
+        i.push(I64Store(3, 8));
+        i.push(End);
+        // header: len (= found ? len : len+1), cap = new_len, data
+        i.push(LocalGet(8));
+        i.push(I32WrapI64);
+        i.push(LocalGet(6));
+        i.push(I64Eqz);
+        i.push(I32Eqz); // 1 if found
+        i.push(If(BlockType::Result(ValType::I64)));
+        i.push(LocalGet(4)); // found: len unchanged
+        i.push(Else);
+        i.push(LocalGet(7)); // not found: len+1
+        i.push(End);
+        i.push(I64Store(3, 0));
+        i.push(LocalGet(8));
+        i.push(I32WrapI64);
+        i.push(LocalGet(7));
+        i.push(I64Store(3, 8)); // cap
+        i.push(LocalGet(8));
+        i.push(I32WrapI64);
+        i.push(LocalGet(9));
+        i.push(I64Store(3, 16)); // data
+        i.push(LocalGet(8));
+        FunctionBody {
+            params: vec![ValType::I64, ValType::I64, ValType::I64, ValType::I64],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64; 8], // locals 4..=11
+            instructions: i,
+        }
+    }
+
+    /// `map_keys(m, vec_new, vec_push) -> i64` — a vector of the keys in order.
+    pub(super) fn gen_map_keys(vec_new: u32, vec_push: u32) -> FunctionBody {
+        // Params: 0=m ; Locals: 1=len,2=data,3=i,4=r
+        let mut i = Vec::new();
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(LocalSet(1));
+        i.push(LocalGet(0));
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 16));
+        i.push(LocalSet(2));
+        i.push(Call(vec_new));
+        i.push(LocalSet(4));
+        i.push(I64Const(0));
+        i.push(LocalSet(3));
+        i.push(Block(BlockType::Empty));
+        i.push(Loop(BlockType::Empty));
+        i.push(LocalGet(3));
+        i.push(LocalGet(1));
+        i.push(I64LtS);
+        i.push(I32Eqz);
+        i.push(BrIf(1));
+        // r = vec_push(r, data[i*16])
+        i.push(LocalGet(4));
+        i.push(LocalGet(2));
+        i.push(LocalGet(3));
+        i.push(I64Const(16));
+        i.push(I64Mul);
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I64Load(3, 0));
+        i.push(Call(vec_push));
+        i.push(LocalSet(4));
+        i.push(LocalGet(3));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(3));
+        i.push(Br(0));
+        i.push(End);
+        i.push(End);
+        i.push(LocalGet(4));
+        FunctionBody {
+            params: vec![ValType::I64],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64, ValType::I64, ValType::I64, ValType::I64],
+            instructions: i,
+        }
+    }
+}

--- a/crates/loon-lang/src/codegen/maps.rs
+++ b/crates/loon-lang/src/codegen/maps.rs
@@ -8,9 +8,12 @@
 //!   offset 16: data_ptr (i64) — points to `capacity * 2` i64 slots
 //!
 //! Operations are copy-on-write for persistence, like vectors. Key comparison
-//! is selected by an `is_str` flag passed from the call site (the compiler
-//! knows the static key type): string keys compare by content via `str_eq`,
-//! everything else by raw i64 equality. Uses global 0 as the bump allocator.
+//! is *self-describing* (see `emit_key_eq`): raw i64 equality first, then a
+//! string-content compare when both keys look like string pointers (their
+//! high-32 bits land in the heap range). This works for string keys even when
+//! the static key type is unknown (e.g. a generic accumulator through `fold`).
+//! The trailing `is_str` parameter on the helpers is now vestigial. Uses global
+//! 0 as the bump allocator.
 
 use super::{FunctionBody, WasmInstruction::*};
 use wasm_encoder::*;
@@ -67,22 +70,45 @@ impl MapRuntime {
         }
     }
 
-    /// Emit: compute key equality of locals `a` and `b` (both i64) under the
-    /// `is_str` flag (local), leaving an i64 0/1 on the stack. Calls `str_eq`.
-    fn emit_key_eq(i: &mut Vec<super::WasmInstruction>, a: u32, b: u32, is_str: u32, str_eq: u32) {
-        i.push(LocalGet(is_str));
-        i.push(I64Eqz); // 1 if not string
-        i.push(If(BlockType::Result(ValType::I64)));
-        // non-string: a == b
+    /// Emit a *self-describing* key equality of locals `a` and `b`, leaving an
+    /// i64 0/1. Fast path: raw `a == b` (covers ints, keywords, and identical
+    /// string pointers). Otherwise, if both values look like string pointers —
+    /// their packed high-32 bits fall in the heap range `[1024, heap_ptr)`,
+    /// which ints (high bits 0) and keyword ids (high bits huge) never do —
+    /// compare by content via `str_eq`. This removes the need for a compile-time
+    /// key-type flag, so string keys work even through generic HOF-threaded code.
+    fn emit_key_eq(i: &mut Vec<super::WasmInstruction>, a: u32, b: u32, str_eq: u32) {
+        // strptr(x): (x>>32) >= 1024 && (x>>32) < heap_ptr  -> i32
+        let push_strptr = |i: &mut Vec<super::WasmInstruction>, x: u32| {
+            i.push(LocalGet(x));
+            i.push(I64Const(32));
+            i.push(I64ShrU);
+            i.push(I64Const(1024));
+            i.push(I64GeS);
+            i.push(LocalGet(x));
+            i.push(I64Const(32));
+            i.push(I64ShrU);
+            i.push(GlobalGet(0));
+            i.push(I64ExtendI32U);
+            i.push(I64LtS);
+            i.push(I32And);
+        };
         i.push(LocalGet(a));
         i.push(LocalGet(b));
         i.push(I64Eq);
-        i.push(I64ExtendI32U);
+        i.push(If(BlockType::Result(ValType::I64)));
+        i.push(I64Const(1));
         i.push(Else);
-        // string: str_eq(a, b)
+        push_strptr(i, a);
+        push_strptr(i, b);
+        i.push(I32And);
+        i.push(If(BlockType::Result(ValType::I64)));
         i.push(LocalGet(a));
         i.push(LocalGet(b));
         i.push(Call(str_eq));
+        i.push(Else);
+        i.push(I64Const(0));
+        i.push(End);
         i.push(End);
     }
 
@@ -119,7 +145,7 @@ impl MapRuntime {
         i.push(I64Load(3, 0));
         i.push(LocalSet(6));
         // if key_eq(ek, k) return data[i*16+8]
-        Self::emit_key_eq(&mut i, 6, 1, 2, str_eq);
+        Self::emit_key_eq(&mut i, 6, 1, str_eq);
         i.push(I64Eqz);
         i.push(I32Eqz); // truthy?
         i.push(If(BlockType::Empty));
@@ -178,7 +204,7 @@ impl MapRuntime {
         i.push(I32WrapI64);
         i.push(I64Load(3, 0));
         i.push(LocalSet(6));
-        Self::emit_key_eq(&mut i, 6, 1, 2, str_eq);
+        Self::emit_key_eq(&mut i, 6, 1, str_eq);
         i.push(I64Eqz);
         i.push(I32Eqz);
         i.push(If(BlockType::Empty));
@@ -272,7 +298,7 @@ impl MapRuntime {
         i.push(LocalGet(11));
         i.push(I64Store(3, 0));
         // value: if key_eq(ek,k) { v ; found=1 } else { old value }
-        Self::emit_key_eq(&mut i, 11, 1, 3, str_eq);
+        Self::emit_key_eq(&mut i, 11, 1, str_eq);
         i.push(I64Eqz);
         i.push(I32Eqz);
         i.push(If(BlockType::Result(ValType::I64)));

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -211,6 +211,7 @@ enum WasmInstruction {
     I64And,
     I64Or,
     I64Shl,
+    I32And,
     I32Add,
     I32Load8U(u32, u32),
     I32Store8(u32, u32),
@@ -426,6 +427,9 @@ fn emit_instruction(f: &mut Function, instr: &WasmInstruction) {
         }
         WasmInstruction::I32Add => {
             f.instruction(&Instruction::I32Add);
+        }
+        WasmInstruction::I32And => {
+            f.instruction(&Instruction::I32And);
         }
         WasmInstruction::I32Eq => {
             f.instruction(&Instruction::I32Eq);
@@ -3666,6 +3670,12 @@ mod tests {
         valid(
             r#"[fn add1 [m k] [assoc m k [+ [get m k] 1]]]
                [fn main [] [let m [fold {} add1 #[5 5 7]]] [println [get m 5]]]"#,
+        );
+        // String keys through a generic accumulator passed to fold — relies on
+        // the self-describing key comparison, not a static key-type flag.
+        valid(
+            r#"[fn add1 [m k] [assoc m k [+ [get m k] 1]]]
+               [fn main [] [let m [fold {} add1 [split "a b a" " "]]] [println [get m "a"]]]"#,
         );
     }
     #[test]

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -4,11 +4,31 @@ pub mod collections;
 #[allow(clippy::vec_init_then_push)]
 pub mod strings;
 
-use crate::ast::{Expr, ExprKind};
+use crate::ast::{Expr, ExprKind, NodeId};
+use crate::types::Type;
 use collections::CollectionsRuntime;
 use std::collections::HashMap;
 use strings::StringRuntime;
 use wasm_encoder::*;
+
+/// Run the type checker over an (already macro-expanded) program and return a
+/// map from each node to its *resolved* type. Codegen consults this to make
+/// type-directed decisions (e.g. how to print a value) rather than re-deriving
+/// the information from syntax. Type errors are ignored here — the checker is a
+/// separate front door (`loon check`); unresolved nodes simply fall back to the
+/// untyped path.
+fn infer_node_types(exprs: &[Expr], base_dir: Option<&std::path::Path>) -> HashMap<NodeId, Type> {
+    let mut checker = match base_dir {
+        Some(dir) => crate::check::Checker::with_base_dir(dir),
+        None => crate::check::Checker::new(),
+    };
+    let _ = checker.check_program(exprs);
+    checker
+        .type_of
+        .iter()
+        .map(|(id, ty)| (*id, checker.resolve(ty)))
+        .collect()
+}
 
 /// Compile a Loon program to WASM bytes.
 pub fn compile(exprs: &[Expr]) -> Result<Vec<u8>, String> {
@@ -17,6 +37,7 @@ pub fn compile(exprs: &[Expr]) -> Result<Vec<u8>, String> {
     let expanded = expander.expand_program(exprs)?;
 
     let mut compiler = Compiler::new();
+    compiler.node_types = infer_node_types(&expanded, None);
     compiler.compile_program(&expanded)?;
     compiler.tree_shake();
     Ok(compiler.finish())
@@ -30,6 +51,7 @@ pub fn compile_with_imports(exprs: &[Expr], base_dir: &std::path::Path) -> Resul
 
     let mut compiler = Compiler::new();
     compiler.base_dir = Some(base_dir.to_path_buf());
+    compiler.node_types = infer_node_types(&expanded, Some(base_dir));
     compiler.compile_program(&expanded)?;
     compiler.tree_shake();
     Ok(compiler.finish())
@@ -96,6 +118,10 @@ struct Compiler {
     /// Distinct keyword literals interned to unique i64 ids (for `=` and use as
     /// enum-like tags). Ids start high to avoid colliding with small ints.
     keywords: HashMap<String, i64>,
+    /// Resolved type of each AST node (from the checker). Lets codegen make
+    /// type-directed choices instead of guessing from syntax. Synthesized nodes
+    /// (desugared `pipe`/`when`/… ) are absent and fall back to the untyped path.
+    node_types: HashMap<NodeId, Type>,
 }
 
 struct FunctionBody {
@@ -397,7 +423,12 @@ impl Compiler {
             effect_registry: crate::effects::EffectRegistry::new(),
             string_fns: std::collections::HashSet::new(),
             keywords: HashMap::new(),
+            node_types: HashMap::new(),
         }
+    }
+    /// The resolved type of an AST node, if the checker inferred one.
+    fn node_type(&self, expr: &Expr) -> Option<&Type> {
+        self.node_types.get(&expr.id)
     }
     /// Intern a keyword to a stable, unique i64 id (high range to avoid
     /// colliding with ordinary integer values under structural `=`).
@@ -1423,6 +1454,11 @@ impl<'a> FnCtx<'a> {
     /// pick the string-printing path when it can prove the argument is a
     /// string at compile time.
     fn expr_is_string(&self, expr: &Expr) -> bool {
+        // Type-directed: trust the checker's resolved type when it has one.
+        if let Some(ty) = self.compiler.node_type(expr) {
+            return matches!(ty, Type::Str);
+        }
+        // Fallback for synthesized nodes (desugared forms) the checker never saw.
         Compiler::expr_returns_string(expr, &self.compiler.string_fns)
     }
     fn compile_expr(&mut self, expr: &Expr) -> Result<(), String> {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -2087,6 +2087,25 @@ impl<'a> FnCtx<'a> {
             ExprKind::List(items) => {
                 if let ExprKind::Symbol(s) = &items[0].kind {
                     if s == "fn" {
+                        // `[fn [params] …]` is an anonymous closure. A nested
+                        // *named* form `[fn name [params] …]` (a local function
+                        // definition inside a body) compiles to a closure value
+                        // bound to `name` in scope.
+                        let named = items.len() >= 3
+                            && matches!(&items[1].kind, ExprKind::Symbol(_))
+                            && matches!(&items[2].kind, ExprKind::List(_));
+                        if named {
+                            let name = match &items[1].kind {
+                                ExprKind::Symbol(n) => n.clone(),
+                                _ => unreachable!(),
+                            };
+                            self.compile_closure(&items[2..])?;
+                            let l = self.alloc_local();
+                            self.instructions.push(WasmInstruction::LocalSet(l));
+                            self.locals.insert(name, l);
+                            self.instructions.push(WasmInstruction::LocalGet(l));
+                            return Ok(());
+                        }
                         return self.compile_closure(&items[1..]);
                     }
                 }
@@ -4133,6 +4152,13 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_nested_named_fn_is_valid() {
+        valid(
+            r#"[fn outer [n] [fn dbl [x] [* x 2]] [+ [dbl n] [dbl 1]]]
+               [fn main [] [println [outer 10]]]"#,
+        );
     }
     #[test]
     fn compile_lowercase_and_builtin_hof_are_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -1904,13 +1904,37 @@ impl<'a> FnCtx<'a> {
     /// Display — covers ints/bools/keywords; floats fall here too and render
     /// their integer value, a known rough edge).
     fn compile_as_string(&mut self, expr: &Expr) -> Result<(), String> {
+        use WasmInstruction as W;
         if self.expr_is_string(expr) {
             return self.compile_expr(expr);
         }
         self.compiler.ensure_string_runtime();
         let its = self.compiler.string_runtime.clone().unwrap().int_to_str_idx;
+        // Statically-known non-string (int/bool/keyword): render via int_to_str.
+        if let Some(ty) = self.compiler.node_type(expr) {
+            if !matches!(ty, Type::Var(_)) {
+                self.compile_expr(expr)?;
+                self.instructions.push(W::Call(its));
+                return Ok(());
+            }
+        }
+        // Unknown static type (e.g. a destructured binding): self-describing —
+        // if the value looks like a string pointer at runtime use it directly,
+        // else stringify as an integer.
+        let x = self.alloc_local();
         self.compile_expr(expr)?;
-        self.instructions.push(WasmInstruction::Call(its));
+        self.instructions.push(W::LocalSet(x));
+        self.instructions.push(W::LocalGet(x));
+        self.instructions.push(W::I64Const(32));
+        self.instructions.push(W::I64ShrU);
+        self.instructions.push(W::I64Const(1024));
+        self.instructions.push(W::I64GeS);
+        self.instructions.push(W::If(BlockType::Result(ValType::I64)));
+        self.instructions.push(W::LocalGet(x));
+        self.instructions.push(W::Else);
+        self.instructions.push(W::LocalGet(x));
+        self.instructions.push(W::Call(its));
+        self.instructions.push(W::End);
         Ok(())
     }
     /// Whether an expression is statically of float type. Trusts the checker's
@@ -2570,12 +2594,35 @@ impl<'a> FnCtx<'a> {
                     return Ok(());
                 }
                 "empty?" => {
-                    // len(v) == 0
+                    // Self-describing: a string value packs its length in the
+                    // low 32 bits (high bits = ptr >= 1024); a vector value is a
+                    // small header address (high bits 0). So check string length
+                    // for the former and the vector's len field for the latter.
+                    use WasmInstruction as W;
+                    let x = self.alloc_local();
                     self.compile_expr(&items[1])?;
-                    self.instructions.push(WasmInstruction::I32WrapI64);
-                    self.instructions.push(WasmInstruction::I64Load(3, 0));
-                    self.instructions.push(WasmInstruction::I64Eqz);
-                    self.instructions.push(WasmInstruction::I64ExtendI32U);
+                    self.instructions.push(W::LocalSet(x));
+                    self.instructions.push(W::LocalGet(x));
+                    self.instructions.push(W::I64Const(32));
+                    self.instructions.push(W::I64ShrU);
+                    self.instructions.push(W::I64Const(1024));
+                    self.instructions.push(W::I64GeS); // i32: looks like a string
+                    self.instructions
+                        .push(W::If(BlockType::Result(ValType::I64)));
+                    // string: (x & 0xffffffff) == 0
+                    self.instructions.push(W::LocalGet(x));
+                    self.instructions.push(W::I64Const(0xFFFF_FFFF));
+                    self.instructions.push(W::I64And);
+                    self.instructions.push(W::I64Eqz);
+                    self.instructions.push(W::I64ExtendI32U);
+                    self.instructions.push(W::Else);
+                    // vector/map: mem[addr].len == 0
+                    self.instructions.push(W::LocalGet(x));
+                    self.instructions.push(W::I32WrapI64);
+                    self.instructions.push(W::I64Load(3, 0));
+                    self.instructions.push(W::I64Eqz);
+                    self.instructions.push(W::I64ExtendI32U);
+                    self.instructions.push(W::End);
                     return Ok(());
                 }
                 "if" => {
@@ -2865,6 +2912,15 @@ impl<'a> FnCtx<'a> {
                         return self.compile_fold(&items[1], &items[2], &items[3]);
                     }
                     return Err("codegen: fold requires init, function, collection".into());
+                }
+                "sort-by" => {
+                    // [sort-by f order coll] — sort coll by integer key f(elem).
+                    if items.len() >= 4 {
+                        let order_desc =
+                            matches!(&items[2].kind, ExprKind::Keyword(k) if k == "desc");
+                        return self.compile_sort_by(&items[1], order_desc, &items[3]);
+                    }
+                    return Err("codegen: sort-by requires function, order, collection".into());
                 }
                 "range" => {
                     // [range a b] — vector of a, a+1, …, b-1.
@@ -3491,6 +3547,208 @@ impl<'a> FnCtx<'a> {
             }
         }
     }
+    /// `[sort-by f order coll]` — stable-ish insertion sort of `coll` by the key
+    /// `f(elem)` (an integer key), ascending unless `order` is `:desc`. Keys are
+    /// precomputed once into a scratch array, then the element array is sorted.
+    fn compile_sort_by(
+        &mut self,
+        f: &Expr,
+        order_desc: bool,
+        coll: &Expr,
+    ) -> Result<(), String> {
+        use WasmInstruction as W;
+        self.compiler.ensure_collections_runtime();
+        let rt = self.compiler.collections_runtime.clone().unwrap();
+        let fr = self.prepare_fn_arg(f)?;
+        self.compile_expr(coll)?;
+        let vl = self.alloc_local();
+        self.instructions.push(W::LocalSet(vl));
+        let (n, data) = self.emit_vec_header(vl);
+        // elems = alloc n*8 ; keys = alloc n*8  (heap offsets as i64)
+        let elems = self.alloc_local();
+        let keys = self.alloc_local();
+        for slot in [elems, keys] {
+            self.instructions.push(W::GlobalGet(0));
+            self.instructions.push(W::I64ExtendI32U);
+            self.instructions.push(W::LocalSet(slot));
+            self.instructions.push(W::GlobalGet(0));
+            self.instructions.push(W::LocalGet(n));
+            self.instructions.push(W::I64Const(8));
+            self.instructions.push(W::I64Mul);
+            self.instructions.push(W::I32WrapI64);
+            self.instructions.push(W::I32Add);
+            self.instructions.push(W::GlobalSet(0));
+        }
+        let iv = self.alloc_local();
+        let eloc = self.alloc_local();
+        // copy elems[i] = data[i]; keys[i] = f(elems[i])
+        self.instructions.push(W::I64Const(0));
+        self.instructions.push(W::LocalSet(iv));
+        self.instructions.push(W::Block(BlockType::Empty));
+        self.instructions.push(W::Loop(BlockType::Empty));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::LocalGet(n));
+        self.instructions.push(W::I64LtS);
+        self.instructions.push(W::I32Eqz);
+        self.instructions.push(W::BrIf(1));
+        // el = data[i]
+        self.instructions.push(W::LocalGet(data));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::I64Const(8));
+        self.instructions.push(W::I64Mul);
+        self.instructions.push(W::I64Add);
+        self.instructions.push(W::I32WrapI64);
+        self.instructions.push(W::I64Load(3, 0));
+        self.instructions.push(W::LocalSet(eloc));
+        // elems[i] = el
+        self.instructions.push(W::LocalGet(elems));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::I64Const(8));
+        self.instructions.push(W::I64Mul);
+        self.instructions.push(W::I64Add);
+        self.instructions.push(W::I32WrapI64);
+        self.instructions.push(W::LocalGet(eloc));
+        self.instructions.push(W::I64Store(3, 0));
+        // keys[i] = f(el)
+        self.instructions.push(W::LocalGet(keys));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::I64Const(8));
+        self.instructions.push(W::I64Mul);
+        self.instructions.push(W::I64Add);
+        self.instructions.push(W::I32WrapI64);
+        self.emit_apply1(&fr, eloc);
+        self.instructions.push(W::I64Store(3, 0));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::I64Add);
+        self.instructions.push(W::LocalSet(iv));
+        self.instructions.push(W::Br(0));
+        self.instructions.push(W::End);
+        self.instructions.push(W::End);
+        // insertion sort: for i in 1..n { ek=elems[i]; kk=keys[i]; j=i-1;
+        //   while j>=0 && cmp(keys[j], kk) { shift; j-- } place }
+        let jv = self.alloc_local();
+        let ek = self.alloc_local();
+        let kk = self.alloc_local();
+        let addr = self.alloc_local(); // scratch addr (i64)
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::LocalSet(iv));
+        self.instructions.push(W::Block(BlockType::Empty));
+        self.instructions.push(W::Loop(BlockType::Empty));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::LocalGet(n));
+        self.instructions.push(W::I64LtS);
+        self.instructions.push(W::I32Eqz);
+        self.instructions.push(W::BrIf(1));
+        // ek = elems[i]; kk = keys[i]
+        let load_at = |s: &mut Vec<WasmInstruction>, base: u32, idx: u32| {
+            s.push(W::LocalGet(base));
+            s.push(W::LocalGet(idx));
+            s.push(W::I64Const(8));
+            s.push(W::I64Mul);
+            s.push(W::I64Add);
+            s.push(W::I32WrapI64);
+            s.push(W::I64Load(3, 0));
+        };
+        load_at(&mut self.instructions, elems, iv);
+        self.instructions.push(W::LocalSet(ek));
+        load_at(&mut self.instructions, keys, iv);
+        self.instructions.push(W::LocalSet(kk));
+        // j = i - 1
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::I64Sub);
+        self.instructions.push(W::LocalSet(jv));
+        // inner while
+        self.instructions.push(W::Block(BlockType::Empty));
+        self.instructions.push(W::Loop(BlockType::Empty));
+        // cond: j >= 0
+        self.instructions.push(W::LocalGet(jv));
+        self.instructions.push(W::I64Const(0));
+        self.instructions.push(W::I64GeS); // i32
+        // && cmp(keys[j], kk)
+        load_at(&mut self.instructions, keys, jv);
+        self.instructions.push(W::LocalSet(addr)); // reuse addr to hold keys[j]
+        self.instructions.push(W::LocalGet(addr));
+        self.instructions.push(W::LocalGet(kk));
+        if order_desc {
+            self.instructions.push(W::I64LtS); // keys[j] < kk -> move (larger first)
+        } else {
+            self.instructions.push(W::I64GtS); // keys[j] > kk
+        }
+        self.instructions.push(W::I32And);
+        self.instructions.push(W::I32Eqz);
+        self.instructions.push(W::BrIf(1)); // exit inner when cond false
+        // elems[j+1] = elems[j]; keys[j+1] = keys[j]
+        for base in [elems, keys] {
+            // dest addr = base + (j+1)*8
+            self.instructions.push(W::LocalGet(base));
+            self.instructions.push(W::LocalGet(jv));
+            self.instructions.push(W::I64Const(1));
+            self.instructions.push(W::I64Add);
+            self.instructions.push(W::I64Const(8));
+            self.instructions.push(W::I64Mul);
+            self.instructions.push(W::I64Add);
+            self.instructions.push(W::I32WrapI64);
+            // value = base[j]
+            load_at(&mut self.instructions, base, jv);
+            self.instructions.push(W::I64Store(3, 0));
+        }
+        // j--
+        self.instructions.push(W::LocalGet(jv));
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::I64Sub);
+        self.instructions.push(W::LocalSet(jv));
+        self.instructions.push(W::Br(0));
+        self.instructions.push(W::End);
+        self.instructions.push(W::End);
+        // place: elems[j+1] = ek ; keys[j+1] = kk
+        for (base, val) in [(elems, ek), (keys, kk)] {
+            self.instructions.push(W::LocalGet(base));
+            self.instructions.push(W::LocalGet(jv));
+            self.instructions.push(W::I64Const(1));
+            self.instructions.push(W::I64Add);
+            self.instructions.push(W::I64Const(8));
+            self.instructions.push(W::I64Mul);
+            self.instructions.push(W::I64Add);
+            self.instructions.push(W::I32WrapI64);
+            self.instructions.push(W::LocalGet(val));
+            self.instructions.push(W::I64Store(3, 0));
+        }
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::I64Add);
+        self.instructions.push(W::LocalSet(iv));
+        self.instructions.push(W::Br(0));
+        self.instructions.push(W::End);
+        self.instructions.push(W::End);
+        // build result vector from sorted elems
+        self.instructions.push(W::Call(rt.vec_new_idx));
+        let rl = self.alloc_local();
+        self.instructions.push(W::LocalSet(rl));
+        self.instructions.push(W::I64Const(0));
+        self.instructions.push(W::LocalSet(iv));
+        self.instructions.push(W::Block(BlockType::Empty));
+        self.instructions.push(W::Loop(BlockType::Empty));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::LocalGet(n));
+        self.instructions.push(W::I64LtS);
+        self.instructions.push(W::I32Eqz);
+        self.instructions.push(W::BrIf(1));
+        self.instructions.push(W::LocalGet(rl));
+        load_at(&mut self.instructions, elems, iv);
+        self.instructions.push(W::Call(rt.vec_push_idx));
+        self.instructions.push(W::LocalSet(rl));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::I64Add);
+        self.instructions.push(W::LocalSet(iv));
+        self.instructions.push(W::Br(0));
+        self.instructions.push(W::End);
+        self.instructions.push(W::End);
+        self.instructions.push(W::LocalGet(rl));
+        Ok(())
+    }
     fn compile_range(&mut self, a: &Expr, b: &Expr) -> Result<(), String> {
         use WasmInstruction as W;
         self.compiler.ensure_collections_runtime();
@@ -3715,6 +3973,14 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_sort_by_is_valid() {
+        valid(r#"[fn id [x] x] [fn main [] [each [fn [x] [println x]] [sort-by id :asc #[3 1 2]]]]"#);
+        valid(
+            r#"[fn main [] [each [fn [[k v]] [println v]]
+                 [sort-by [fn [[_ n]] n] :desc [entries {:a 1 :b 2}]]]]"#,
+        );
     }
     #[test]
     fn compile_entries_and_destructuring_are_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -600,12 +600,19 @@ impl Compiler {
             keys_idx,
             MapRuntime::gen_map_keys(cr.vec_new_idx, cr.vec_push_idx),
         );
+        let entries_idx = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(
+            entries_idx,
+            MapRuntime::gen_map_entries(cr.vec_new_idx, cr.vec_push_idx),
+        );
         self.map_runtime = Some(MapRuntime {
             map_new_idx: new_idx,
             map_set_idx: set_idx,
             map_get_idx: get_idx,
             map_has_idx: has_idx,
             map_keys_idx: keys_idx,
+            map_entries_idx: entries_idx,
         });
     }
     fn ensure_split_runtime(&mut self) -> u32 {
@@ -2487,6 +2494,14 @@ impl<'a> FnCtx<'a> {
                     self.instructions.push(WasmInstruction::Call(rt.map_keys_idx));
                     return Ok(());
                 }
+                "entries" => {
+                    self.compiler.ensure_map_runtime();
+                    let rt = self.compiler.map_runtime.clone().unwrap();
+                    self.compile_expr(&items[1])?;
+                    self.instructions
+                        .push(WasmInstruction::Call(rt.map_entries_idx));
+                    return Ok(());
+                }
                 "take" => {
                     // [take n v] -> new vector of the first min(n, len) elems.
                     self.compiler.ensure_collections_runtime();
@@ -3128,19 +3143,30 @@ impl<'a> FnCtx<'a> {
         if args.is_empty() {
             return Err("closure requires params".into());
         }
-        let params = match &args[0].kind {
-            ExprKind::List(items) => items
-                .iter()
-                .filter_map(|p| {
-                    if let ExprKind::Symbol(s) = &p.kind {
-                        Some(s.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<_>>(),
+        // Params may be plain symbols or destructuring patterns ([a b] for a
+        // pair). `param_exprs` keeps the raw forms; `bound_names` is the flat
+        // list of names they bind (used to exclude them from captures).
+        let param_exprs: Vec<Expr> = match &args[0].kind {
+            ExprKind::List(items) => items.clone(),
             _ => return Err("closure params must be a list".into()),
         };
+        let mut bound_names: Vec<String> = Vec::new();
+        for p in &param_exprs {
+            match &p.kind {
+                ExprKind::Symbol(s) => bound_names.push(s.clone()),
+                ExprKind::List(sub) | ExprKind::Tuple(sub) => {
+                    for e in sub {
+                        if let ExprKind::Symbol(s) = &e.kind {
+                            if s != "_" {
+                                bound_names.push(s.clone());
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        let params = bound_names.clone();
         let body = &args[1..];
         let free = capture::free_vars(&params, body);
         let mut captures: Vec<(String, u32)> = Vec::new();
@@ -3151,7 +3177,7 @@ impl<'a> FnCtx<'a> {
         }
         let lname = format!("__closure_{}", self.compiler.lambda_counter);
         self.compiler.lambda_counter += 1;
-        let tp = 1 + params.len();
+        let tp = 1 + param_exprs.len();
         let idx = self.compiler.next_fn_idx;
         self.compiler.fn_map.insert(
             lname,
@@ -3174,8 +3200,32 @@ impl<'a> FnCtx<'a> {
             string_locals: std::collections::HashSet::new(),
         };
         cctx.locals.insert("__env_ptr".to_string(), 0);
-        for (i, p) in params.iter().enumerate() {
-            cctx.locals.insert(p.clone(), (i + 1) as u32);
+        for (i, p) in param_exprs.iter().enumerate() {
+            let pos = (i + 1) as u32; // positional local (after __env_ptr)
+            match &p.kind {
+                ExprKind::Symbol(s) => {
+                    cctx.locals.insert(s.clone(), pos);
+                }
+                ExprKind::List(sub) | ExprKind::Tuple(sub) => {
+                    // Destructure a pair/tuple arg: name_j = vec-get(arg, j).
+                    cctx.compiler.ensure_collections_runtime();
+                    let vget = cctx.compiler.collections_runtime.clone().unwrap().vec_get_idx;
+                    for (j, e) in sub.iter().enumerate() {
+                        if let ExprKind::Symbol(s) = &e.kind {
+                            if s == "_" {
+                                continue;
+                            }
+                            let l = cctx.alloc_local();
+                            cctx.instructions.push(WasmInstruction::LocalGet(pos));
+                            cctx.instructions.push(WasmInstruction::I64Const(j as i64));
+                            cctx.instructions.push(WasmInstruction::Call(vget));
+                            cctx.instructions.push(WasmInstruction::LocalSet(l));
+                            cctx.locals.insert(s.clone(), l);
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
         for (ci, (cn, _)) in captures.iter().enumerate() {
             let l = cctx.alloc_local();
@@ -3665,6 +3715,12 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_entries_and_destructuring_are_valid() {
+        valid(r#"[fn main [] [println [len [entries {:a 1 :b 2 :c 3}]]]]"#);
+        valid(r#"[fn main [] [each [fn [[k v]] [println v]] [entries {:a 10 :b 20}]]]"#);
+        valid(r#"[fn main [] [each [fn [[_ v]] [println v]] [entries {:x 7}]]]"#);
     }
     #[test]
     fn compile_update_is_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -1998,6 +1998,16 @@ impl<'a> FnCtx<'a> {
                     );
                 }
                 "=" => {
+                    // String equality is structural (str_eq), not pointer
+                    // identity — type-directed when either side is a string.
+                    if self.expr_is_string(&items[1]) || self.expr_is_string(&items[2]) {
+                        self.compiler.ensure_string_runtime();
+                        let rt = self.compiler.string_runtime.clone().unwrap();
+                        self.compile_expr(&items[1])?;
+                        self.compile_expr(&items[2])?;
+                        self.instructions.push(WasmInstruction::Call(rt.str_eq_idx));
+                        return Ok(());
+                    }
                     return self.compile_cmp(
                         &items[1],
                         &items[2],
@@ -2006,6 +2016,17 @@ impl<'a> FnCtx<'a> {
                     );
                 }
                 "!=" => {
+                    if self.expr_is_string(&items[1]) || self.expr_is_string(&items[2]) {
+                        self.compiler.ensure_string_runtime();
+                        let rt = self.compiler.string_runtime.clone().unwrap();
+                        self.compile_expr(&items[1])?;
+                        self.compile_expr(&items[2])?;
+                        self.instructions.push(WasmInstruction::Call(rt.str_eq_idx));
+                        // negate: (str_eq == 0)
+                        self.instructions.push(WasmInstruction::I64Eqz);
+                        self.instructions.push(WasmInstruction::I64ExtendI32U);
+                        return Ok(());
+                    }
                     return self.compile_cmp(
                         &items[1],
                         &items[2],
@@ -3339,6 +3360,12 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_string_equality_is_structural() {
+        // `=` on strings must compare content (str_eq), not pointer identity.
+        valid(r#"[fn main [] [println [if [= [str "a" "b"] "ab"] 1 0]]]"#);
+        valid(r#"[fn main [] [println [if [!= [str "a" "b"] "ac"] 1 0]]]"#);
     }
     #[test]
     fn compile_floats_are_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -122,6 +122,13 @@ struct Compiler {
     /// type-directed choices instead of guessing from syntax. Synthesized nodes
     /// (desugared `pipe`/`when`/… ) are absent and fall back to the untyped path.
     node_types: HashMap<NodeId, Type>,
+    /// Function keys (`name`/`name#arity`) whose result is float. The checker
+    /// generalizes polymorphic bodies, so concrete float-ness of a function's
+    /// result and params isn't on the body nodes — this structural fixpoint
+    /// recovers it so float ops compile inside function bodies.
+    float_fns: std::collections::HashSet<String>,
+    /// For each function key, the names of its float-typed parameters.
+    float_params: HashMap<String, Vec<String>>,
 }
 
 struct FunctionBody {
@@ -159,6 +166,17 @@ enum WasmInstruction {
     F64Add,
     F64Sub,
     F64Mul,
+    F64Div,
+    F64Lt,
+    F64Gt,
+    F64Le,
+    F64Ge,
+    F64Eq,
+    F64Ne,
+    F64ReinterpretI64,
+    I64ReinterpretF64,
+    F64ConvertI64S,
+    I64TruncF64S,
     LocalGet(u32),
     LocalSet(u32),
     LocalTee(u32),
@@ -249,6 +267,39 @@ fn emit_instruction(f: &mut Function, instr: &WasmInstruction) {
         }
         WasmInstruction::F64Mul => {
             f.instruction(&Instruction::F64Mul);
+        }
+        WasmInstruction::F64Div => {
+            f.instruction(&Instruction::F64Div);
+        }
+        WasmInstruction::F64Lt => {
+            f.instruction(&Instruction::F64Lt);
+        }
+        WasmInstruction::F64Gt => {
+            f.instruction(&Instruction::F64Gt);
+        }
+        WasmInstruction::F64Le => {
+            f.instruction(&Instruction::F64Le);
+        }
+        WasmInstruction::F64Ge => {
+            f.instruction(&Instruction::F64Ge);
+        }
+        WasmInstruction::F64Eq => {
+            f.instruction(&Instruction::F64Eq);
+        }
+        WasmInstruction::F64Ne => {
+            f.instruction(&Instruction::F64Ne);
+        }
+        WasmInstruction::F64ReinterpretI64 => {
+            f.instruction(&Instruction::F64ReinterpretI64);
+        }
+        WasmInstruction::I64ReinterpretF64 => {
+            f.instruction(&Instruction::I64ReinterpretF64);
+        }
+        WasmInstruction::F64ConvertI64S => {
+            f.instruction(&Instruction::F64ConvertI64S);
+        }
+        WasmInstruction::I64TruncF64S => {
+            f.instruction(&Instruction::I64TruncF64S);
         }
         WasmInstruction::LocalGet(i) => {
             f.instruction(&Instruction::LocalGet(*i));
@@ -424,6 +475,8 @@ impl Compiler {
             string_fns: std::collections::HashSet::new(),
             keywords: HashMap::new(),
             node_types: HashMap::new(),
+            float_fns: std::collections::HashSet::new(),
+            float_params: HashMap::new(),
         }
     }
     /// The resolved type of an AST node, if the checker inferred one.
@@ -593,6 +646,7 @@ impl Compiler {
             }
         }
         self.analyze_string_fns(exprs);
+        self.analyze_floats(exprs);
         for expr in exprs {
             if let ExprKind::List(items) = &expr.kind {
                 if items.len() >= 3 {
@@ -653,6 +707,174 @@ impl Compiler {
                 break;
             }
         }
+    }
+    /// Structural float check: whether `e` evaluates to a float, given the set
+    /// of in-scope float-named bindings and the known float-returning functions.
+    /// Used both by the whole-program fixpoint and (at runtime) by codegen.
+    fn is_float_static(
+        e: &Expr,
+        floats: &std::collections::HashSet<String>,
+        float_fns: &std::collections::HashSet<String>,
+    ) -> bool {
+        match &e.kind {
+            ExprKind::Float(_) => true,
+            ExprKind::Symbol(s) => floats.contains(s),
+            ExprKind::List(items) if !items.is_empty() => {
+                if let ExprKind::Symbol(h) = &items[0].kind {
+                    let argc = items.len() - 1;
+                    match h.as_str() {
+                        "+" | "-" | "*" | "/" | "min" | "max" if argc >= 2 => {
+                            Self::is_float_static(&items[1], floats, float_fns)
+                                || Self::is_float_static(&items[2], floats, float_fns)
+                        }
+                        "abs" | "inc" | "dec" if argc >= 1 => {
+                            Self::is_float_static(&items[1], floats, float_fns)
+                        }
+                        "if" if argc >= 3 => {
+                            Self::is_float_static(&items[2], floats, float_fns)
+                                || Self::is_float_static(&items[3], floats, float_fns)
+                        }
+                        "do" => items
+                            .last()
+                            .is_some_and(|x| Self::is_float_static(x, floats, float_fns)),
+                        _ => {
+                            float_fns.contains(h.as_str())
+                                || float_fns.contains(&format!("{h}#{argc}"))
+                        }
+                    }
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+    /// Whole-program fixpoint recovering which functions return floats and which
+    /// of their parameters are float. The checker generalizes polymorphic
+    /// bodies, so this structural pass fills the gap for monomorphic float use.
+    fn analyze_floats(&mut self, exprs: &[Expr]) {
+        // fn key -> param names; and (key, last body expr) per clause.
+        let mut fn_params: HashMap<String, Vec<String>> = HashMap::new();
+        let mut fn_bodies: Vec<(String, &Expr)> = Vec::new();
+        // (enclosing fn key, callee name, arg exprs)
+        let mut calls: Vec<(Option<String>, String, Vec<&Expr>)> = Vec::new();
+        fn collect_calls<'e>(
+            e: &'e Expr,
+            enc: Option<&str>,
+            out: &mut Vec<(Option<String>, String, Vec<&'e Expr>)>,
+        ) {
+            match &e.kind {
+                ExprKind::List(items) if !items.is_empty() => {
+                    if let ExprKind::Symbol(h) = &items[0].kind {
+                        if h == "fn" {
+                            return; // don't descend into nested closures
+                        }
+                        out.push((
+                            enc.map(String::from),
+                            h.clone(),
+                            items[1..].iter().collect(),
+                        ));
+                    }
+                    for it in items {
+                        collect_calls(it, enc, out);
+                    }
+                }
+                ExprKind::Vec(items) | ExprKind::Set(items) | ExprKind::Tuple(items) => {
+                    for it in items {
+                        collect_calls(it, enc, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+        for expr in exprs {
+            if let ExprKind::List(items) = &expr.kind {
+                if items.len() >= 3 && matches!(&items[0].kind, ExprKind::Symbol(s) if s == "fn") {
+                    if let ExprKind::Symbol(name) = &items[1].kind {
+                        let args = &items[1..];
+                        if Self::is_multi_arity(args) {
+                            for clause in &args[1..] {
+                                if let ExprKind::Tuple(parts) = &clause.kind {
+                                    if let Some(ExprKind::List(params)) =
+                                        parts.first().map(|e| &e.kind)
+                                    {
+                                        let pnames = Self::param_names(params);
+                                        let key = format!("{name}#{}", pnames.len());
+                                        fn_params.insert(key.clone(), pnames);
+                                        if let Some(last) = parts.last() {
+                                            fn_bodies.push((key.clone(), last));
+                                        }
+                                        for p in &parts[1..] {
+                                            collect_calls(p, Some(&key), &mut calls);
+                                        }
+                                    }
+                                }
+                            }
+                        } else if let ExprKind::List(params) = &items[2].kind {
+                            let pnames = Self::param_names(params);
+                            fn_params.insert(name.clone(), pnames);
+                            if let Some(last) = items.last() {
+                                fn_bodies.push((name.clone(), last));
+                            }
+                            for p in &items[3..] {
+                                collect_calls(p, Some(name), &mut calls);
+                            }
+                        }
+                    }
+                } else {
+                    collect_calls(expr, None, &mut calls);
+                }
+            }
+        }
+        let mut float_fns: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut float_params: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
+        loop {
+            let mut changed = false;
+            for (key, last) in &fn_bodies {
+                let names = float_params.get(key).cloned().unwrap_or_default();
+                if !float_fns.contains(key) && Self::is_float_static(last, &names, &float_fns) {
+                    float_fns.insert(key.clone());
+                    changed = true;
+                }
+            }
+            for (enc, callee, args) in &calls {
+                let callee_key = if fn_params.contains_key(callee) {
+                    callee.clone()
+                } else {
+                    let k = format!("{callee}#{}", args.len());
+                    if fn_params.contains_key(&k) {
+                        k
+                    } else {
+                        continue;
+                    }
+                };
+                let enc_names = enc
+                    .as_ref()
+                    .and_then(|k| float_params.get(k))
+                    .cloned()
+                    .unwrap_or_default();
+                let pnames = fn_params[&callee_key].clone();
+                for (i, arg) in args.iter().enumerate() {
+                    if i >= pnames.len() {
+                        break;
+                    }
+                    if Self::is_float_static(arg, &enc_names, &float_fns) {
+                        let set = float_params.entry(callee_key.clone()).or_default();
+                        if set.insert(pnames[i].clone()) {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        self.float_fns = float_fns;
+        self.float_params = float_params
+            .into_iter()
+            .map(|(k, v)| (k, v.into_iter().collect()))
+            .collect();
     }
     /// Whether an expression statically evaluates to a string, consulting the
     /// set of known string-returning functions for calls. Conservative.
@@ -1030,6 +1252,12 @@ impl Compiler {
         params: &[String],
         body: &[Expr],
     ) -> Result<(), String> {
+        // Params known to be float (from the float fixpoint) seed float_locals.
+        let float_locals: std::collections::HashSet<String> = self
+            .float_params
+            .get(key)
+            .map(|v| v.iter().cloned().collect())
+            .unwrap_or_default();
         let mut ctx = FnCtx {
             locals: HashMap::new(),
             local_count: params.len() as u32,
@@ -1037,6 +1265,7 @@ impl Compiler {
             compiler: self,
             loop_starts: Vec::new(),
             loop_vars: Vec::new(),
+            float_locals,
         };
         for (i, p) in params.iter().enumerate() {
             ctx.locals.insert(p.clone(), i as u32);
@@ -1300,6 +1529,9 @@ struct FnCtx<'a> {
     /// op (to compute `recur`'s branch depth) and its loop-variable locals.
     loop_starts: Vec<usize>,
     loop_vars: Vec<Vec<u32>>,
+    /// Names of in-scope bindings (params + lets) known to hold float values,
+    /// so arithmetic on them picks the f64 path.
+    float_locals: std::collections::HashSet<String>,
 }
 
 impl<'a> FnCtx<'a> {
@@ -1461,20 +1693,78 @@ impl<'a> FnCtx<'a> {
         // Fallback for synthesized nodes (desugared forms) the checker never saw.
         Compiler::expr_returns_string(expr, &self.compiler.string_fns)
     }
+    /// Whether an expression is statically of float type. Trusts the checker's
+    /// concrete type when present; otherwise falls back to a structural check
+    /// (the checker generalizes polymorphic function bodies, so body nodes
+    /// often carry a type var rather than `Float`).
+    fn expr_is_float(&self, expr: &Expr) -> bool {
+        match self.compiler.node_type(expr) {
+            Some(Type::Float) => return true,
+            // A concrete non-float type is authoritative.
+            Some(t) if !matches!(t, Type::Var(_)) => return false,
+            _ => {}
+        }
+        Compiler::is_float_static(expr, &self.float_locals, &self.compiler.float_fns)
+    }
+    /// Compile a binary arithmetic op, choosing the i64 or f64 instruction by
+    /// the operands' static type. Float values are carried as f64 bits in the
+    /// i64 slot, so the float path reinterprets in and out.
+    fn compile_arith(
+        &mut self,
+        a: &Expr,
+        b: &Expr,
+        iop: WasmInstruction,
+        fop: WasmInstruction,
+    ) -> Result<(), String> {
+        if self.expr_is_float(a) || self.expr_is_float(b) {
+            self.compile_expr(a)?;
+            self.instructions.push(WasmInstruction::F64ReinterpretI64);
+            self.compile_expr(b)?;
+            self.instructions.push(WasmInstruction::F64ReinterpretI64);
+            self.instructions.push(fop);
+            self.instructions.push(WasmInstruction::I64ReinterpretF64);
+        } else {
+            self.compile_expr(a)?;
+            self.compile_expr(b)?;
+            self.instructions.push(iop);
+        }
+        Ok(())
+    }
+    /// Compile a comparison, choosing i64 or f64 by operand type. Both paths
+    /// yield an i32 which is widened to the i64 boolean value model.
+    fn compile_cmp(
+        &mut self,
+        a: &Expr,
+        b: &Expr,
+        iop: WasmInstruction,
+        fop: WasmInstruction,
+    ) -> Result<(), String> {
+        if self.expr_is_float(a) || self.expr_is_float(b) {
+            self.compile_expr(a)?;
+            self.instructions.push(WasmInstruction::F64ReinterpretI64);
+            self.compile_expr(b)?;
+            self.instructions.push(WasmInstruction::F64ReinterpretI64);
+            self.instructions.push(fop);
+        } else {
+            self.compile_expr(a)?;
+            self.compile_expr(b)?;
+            self.instructions.push(iop);
+        }
+        self.instructions.push(WasmInstruction::I64ExtendI32U);
+        Ok(())
+    }
     fn compile_expr(&mut self, expr: &Expr) -> Result<(), String> {
         match &expr.kind {
             ExprKind::Int(n) => {
                 self.instructions.push(WasmInstruction::I64Const(*n));
                 Ok(())
             }
-            ExprKind::Float(_) => {
-                // The value model is untagged i64; arithmetic emits i64 ops, so
-                // an f64 here yields a module the validator rejects. Fail
-                // cleanly until there's a typed/tagged value model. (Runs on the
-                // VM via `loon run`.)
-                Err("codegen: floating-point values are not supported by the wasm \
-                     backend yet; run with `loon run`"
-                    .into())
+            ExprKind::Float(n) => {
+                // Floats are carried as their f64 bit-pattern in the i64 value
+                // slot; arithmetic/comparison reinterpret to f64 at the op.
+                self.instructions
+                    .push(WasmInstruction::I64Const(n.to_bits() as i64));
+                Ok(())
             }
             ExprKind::Keyword(k) => {
                 let id = self.compiler.intern_keyword(k);
@@ -1542,72 +1832,84 @@ impl<'a> FnCtx<'a> {
         if let ExprKind::Symbol(s) = &items[0].kind {
             match s.as_str() {
                 "+" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64Add);
-                    return Ok(());
+                    return self.compile_arith(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64Add,
+                        WasmInstruction::F64Add,
+                    );
                 }
                 "-" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64Sub);
-                    return Ok(());
+                    return self.compile_arith(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64Sub,
+                        WasmInstruction::F64Sub,
+                    );
                 }
                 "*" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64Mul);
-                    return Ok(());
-                }
-                ">" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64GtS);
-                    // Comparisons produce an i32; values are i64 throughout
-                    // (incl. `if` conditions and booleans-as-values), so widen.
-                    self.instructions.push(WasmInstruction::I64ExtendI32U);
-                    return Ok(());
-                }
-                "<" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64LtS);
-                    self.instructions.push(WasmInstruction::I64ExtendI32U);
-                    return Ok(());
-                }
-                "=" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64Eq);
-                    self.instructions.push(WasmInstruction::I64ExtendI32U);
-                    return Ok(());
-                }
-                "!=" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64Ne);
-                    self.instructions.push(WasmInstruction::I64ExtendI32U);
-                    return Ok(());
-                }
-                "<=" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64LeS);
-                    self.instructions.push(WasmInstruction::I64ExtendI32U);
-                    return Ok(());
-                }
-                ">=" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64GeS);
-                    self.instructions.push(WasmInstruction::I64ExtendI32U);
-                    return Ok(());
+                    return self.compile_arith(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64Mul,
+                        WasmInstruction::F64Mul,
+                    );
                 }
                 "/" => {
-                    self.compile_expr(&items[1])?;
-                    self.compile_expr(&items[2])?;
-                    self.instructions.push(WasmInstruction::I64DivS);
-                    return Ok(());
+                    return self.compile_arith(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64DivS,
+                        WasmInstruction::F64Div,
+                    );
+                }
+                ">" => {
+                    return self.compile_cmp(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64GtS,
+                        WasmInstruction::F64Gt,
+                    );
+                }
+                "<" => {
+                    return self.compile_cmp(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64LtS,
+                        WasmInstruction::F64Lt,
+                    );
+                }
+                "=" => {
+                    return self.compile_cmp(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64Eq,
+                        WasmInstruction::F64Eq,
+                    );
+                }
+                "!=" => {
+                    return self.compile_cmp(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64Ne,
+                        WasmInstruction::F64Ne,
+                    );
+                }
+                "<=" => {
+                    return self.compile_cmp(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64LeS,
+                        WasmInstruction::F64Le,
+                    );
+                }
+                ">=" => {
+                    return self.compile_cmp(
+                        &items[1],
+                        &items[2],
+                        WasmInstruction::I64GeS,
+                        WasmInstruction::F64Ge,
+                    );
                 }
                 "%" | "mod" => {
                     self.compile_expr(&items[1])?;
@@ -1846,6 +2148,10 @@ impl<'a> FnCtx<'a> {
                         ExprKind::Symbol(s) => s.clone(),
                         _ => return Err("let binding must be a symbol".into()),
                     };
+                    // Remember float-typed bindings so later uses pick f64 ops.
+                    if self.expr_is_float(&items[vi]) {
+                        self.float_locals.insert(name.clone());
+                    }
                     self.compile_expr(&items[vi])?;
                     let local = self.alloc_local();
                     self.locals.insert(name, local);
@@ -2417,6 +2723,7 @@ impl<'a> FnCtx<'a> {
             compiler: self.compiler,
             loop_starts: Vec::new(),
             loop_vars: Vec::new(),
+            float_locals: std::collections::HashSet::new(),
         };
         cctx.locals.insert("__env_ptr".to_string(), 0);
         for (i, p) in params.iter().enumerate() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -2144,6 +2144,19 @@ impl<'a> FnCtx<'a> {
                     self.compiler.adt_constructors.get(name.as_str()).cloned()
                 {
                     self.compile_adt_constructor(name, tag, 0, &[])
+                } else if let Some(def) = self.compiler.fn_map.get(name).cloned() {
+                    // A bare reference to a top-level function is a first-class
+                    // value: wrap it in a closure `[fn [a…] [name a…]]` so it can
+                    // be passed around and called through the table.
+                    let sp = expr.span;
+                    let params: Vec<Expr> = (0..def.arity)
+                        .map(|i| Expr::new(ExprKind::Symbol(format!("__a{i}")), sp))
+                        .collect();
+                    let mut call = vec![Expr::new(ExprKind::Symbol(name.clone()), sp)];
+                    call.extend(params.iter().cloned());
+                    let params_list = Expr::new(ExprKind::List(params), sp);
+                    let body = Expr::new(ExprKind::List(call), sp);
+                    self.compile_closure(&[params_list, body])
                 } else {
                     Err(format!("codegen: unbound symbol '{name}'"))
                 }
@@ -3349,6 +3362,18 @@ impl<'a> FnCtx<'a> {
             let pat = &clauses[i];
             let hbody = &clauses[i + 1];
             i += 2;
+            // A handler clause that *returns a function* is the escaping /
+            // parameter-passing pattern (e.g. the State effect) — that needs
+            // reified, non-tail-resumptive continuations, which this backend
+            // can't express. Fail clearly rather than miscompile.
+            if matches!(&hbody.kind, ExprKind::List(h)
+                if matches!(h.first().map(|e| &e.kind), Some(ExprKind::Symbol(s)) if s == "fn"))
+            {
+                return Err("codegen: escaping/multi-shot continuations (a handler \
+                            returning a function) are not supported by the wasm \
+                            backend; run on the VM with `loon run`"
+                    .into());
+            }
             let parts = match &pat.kind {
                 ExprKind::List(p) if !p.is_empty() => p,
                 _ => continue,

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -537,11 +537,15 @@ impl Compiler {
         let sub = self.next_fn_idx;
         self.next_fn_idx += 1;
         self.push_function(sub, StringRuntime::gen_str_substring());
+        let its = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(its, StringRuntime::gen_int_to_str());
         self.string_runtime = Some(StringRuntime {
             str_concat_idx: c,
             str_len_idx: l,
             str_eq_idx: e,
             str_substring_idx: sub,
+            int_to_str_idx: its,
         });
     }
     fn ensure_collections_runtime(&mut self) {
@@ -1884,6 +1888,20 @@ impl<'a> FnCtx<'a> {
         // Generalized/synthesized nodes: structural fallback.
         Compiler::is_str_static(expr, &self.string_locals, &self.compiler.string_fns)
     }
+    /// Compile `expr` so it leaves a packed *string* on the stack: strings are
+    /// used as-is; other values are rendered via `int_to_str` (type-directed
+    /// Display — covers ints/bools/keywords; floats fall here too and render
+    /// their integer value, a known rough edge).
+    fn compile_as_string(&mut self, expr: &Expr) -> Result<(), String> {
+        if self.expr_is_string(expr) {
+            return self.compile_expr(expr);
+        }
+        self.compiler.ensure_string_runtime();
+        let its = self.compiler.string_runtime.clone().unwrap().int_to_str_idx;
+        self.compile_expr(expr)?;
+        self.instructions.push(WasmInstruction::Call(its));
+        Ok(())
+    }
     /// Whether an expression is statically of float type. Trusts the checker's
     /// concrete type when present; otherwise falls back to a structural check
     /// (the checker generalizes polymorphic function bodies, so body nodes
@@ -2245,8 +2263,8 @@ impl<'a> FnCtx<'a> {
                     return Ok(());
                 }
                 "str-concat" | "str" => {
-                    // Variadic: fold str_concat left-to-right over all args.
-                    // [str] -> "", [str a] -> a, [str a b c] -> concat(concat(a,b),c).
+                    // Variadic: stringify each arg (type-directed Display) and
+                    // fold str_concat. [str] -> "", [str a] -> a.
                     let args = &items[1..];
                     if args.is_empty() {
                         let (offset, len) = self.compiler.intern_string("");
@@ -2254,12 +2272,12 @@ impl<'a> FnCtx<'a> {
                             .push(WasmInstruction::I64Const(((offset as i64) << 32) | len as i64));
                         return Ok(());
                     }
-                    self.compile_expr(&args[0])?;
+                    self.compile_as_string(&args[0])?;
                     if args.len() > 1 {
                         self.compiler.ensure_string_runtime();
                         let rt = self.compiler.string_runtime.clone().unwrap();
                         for arg in &args[1..] {
-                            self.compile_expr(arg)?;
+                            self.compile_as_string(arg)?;
                             self.instructions
                                 .push(WasmInstruction::Call(rt.str_concat_idx));
                         }
@@ -3556,6 +3574,13 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_str_stringifies_ints() {
+        // Type-directed Display: non-string args to `str` render via int_to_str.
+        valid(r#"[fn main [] [println [str "k" 42]]]"#);
+        valid(r#"[fn main [] [println [str "n=" 7 "!"]]]"#);
+        valid(r#"[fn main [] [println [str 123]]]"#);
     }
     #[test]
     fn compile_split_and_cons_are_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -610,6 +610,9 @@ impl Compiler {
             entries_idx,
             MapRuntime::gen_map_entries(cr.vec_new_idx, cr.vec_push_idx),
         );
+        let merge_idx = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(merge_idx, MapRuntime::gen_map_merge(set_idx));
         self.map_runtime = Some(MapRuntime {
             map_new_idx: new_idx,
             map_set_idx: set_idx,
@@ -617,6 +620,7 @@ impl Compiler {
             map_has_idx: has_idx,
             map_keys_idx: keys_idx,
             map_entries_idx: entries_idx,
+            map_merge_idx: merge_idx,
         });
     }
     fn ensure_split_runtime(&mut self) -> u32 {
@@ -2606,6 +2610,15 @@ impl<'a> FnCtx<'a> {
                         .push(WasmInstruction::Call(rt.map_entries_idx));
                     return Ok(());
                 }
+                "merge" => {
+                    self.compiler.ensure_map_runtime();
+                    let rt = self.compiler.map_runtime.clone().unwrap();
+                    self.compile_expr(&items[1])?;
+                    self.compile_expr(&items[2])?;
+                    self.instructions
+                        .push(WasmInstruction::Call(rt.map_merge_idx));
+                    return Ok(());
+                }
                 "take" => {
                     // [take n v] -> new vector of the first min(n, len) elems.
                     self.compiler.ensure_collections_runtime();
@@ -4179,6 +4192,13 @@ mod tests {
         valid(r#"[fn main [] [println [len [entries {:a 1 :b 2 :c 3}]]]]"#);
         valid(r#"[fn main [] [each [fn [[k v]] [println v]] [entries {:a 10 :b 20}]]]"#);
         valid(r#"[fn main [] [each [fn [[_ v]] [println v]] [entries {:x 7}]]]"#);
+    }
+    #[test]
+    fn compile_merge_is_valid() {
+        valid(
+            r#"[fn main [] [let m [merge {:a 1 :b 2} {:b 9 :c 3}]]
+               [println [get m :a]] [println [get m :b]] [println [get m :c]]]"#,
+        );
     }
     #[test]
     fn compile_update_is_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -999,10 +999,6 @@ impl Compiler {
         }
     }
     fn tree_shake(&mut self) {
-        let main_idx = match self.fn_map.get("main") {
-            Some(def) => def.func_idx,
-            None => return,
-        };
         // Map provisional func index → position in `self.functions`. Only
         // compiled functions (not imports) have a body to traverse.
         let mut id_to_pos: HashMap<u32, usize> = HashMap::new();
@@ -1011,8 +1007,23 @@ impl Compiler {
         }
         let mut reachable = std::collections::HashSet::new();
         let mut queue = std::collections::VecDeque::new();
-        reachable.insert(main_idx);
-        queue.push_back(main_idx);
+        // Root the reachability at `main`. With no `main` (e.g. a top-level
+        // script or a library module), keep *all* functions — we can't prune,
+        // but this pass also performs the essential index relocation, so it
+        // must still run to keep Call targets / `_start` consistent.
+        match self.fn_map.get("main") {
+            Some(def) => {
+                reachable.insert(def.func_idx);
+                queue.push_back(def.func_idx);
+            }
+            None => {
+                for &id in &self.fn_indices {
+                    if reachable.insert(id) {
+                        queue.push_back(id);
+                    }
+                }
+            }
+        }
         while let Some(idx) = queue.pop_front() {
             let pos = match id_to_pos.get(&idx) {
                 Some(&p) => p,
@@ -1315,16 +1326,15 @@ impl Compiler {
             for clause in &args[1..] {
                 if let ExprKind::Tuple(parts) = &clause.kind {
                     if let Some(ExprKind::List(params)) = parts.first().map(|e| &e.kind) {
-                        let names = Self::param_names(params);
-                        let key = format!("{name}#{}", names.len());
-                        self.compile_fn_body(&key, false, &names, &parts[1..])?;
+                        let key = format!("{name}#{}", params.len());
+                        self.compile_fn_body(&key, false, params, &parts[1..])?;
                     }
                 }
             }
             return Ok(());
         }
-        let params = match &args[1].kind {
-            ExprKind::List(items) => Self::param_names(items),
+        let params: Vec<Expr> = match &args[1].kind {
+            ExprKind::List(items) => items.clone(),
             _ => return Err("defn params must be a list".into()),
         };
         let mut body_start = 2;
@@ -1345,9 +1355,10 @@ impl Compiler {
         &mut self,
         key: &str,
         is_main: bool,
-        params: &[String],
+        param_exprs: &[Expr],
         body: &[Expr],
     ) -> Result<(), String> {
+        let arity = param_exprs.len();
         // Params known to be float/string (from the fixpoint) seed the locals.
         let float_locals: std::collections::HashSet<String> = self
             .float_params
@@ -1361,7 +1372,7 @@ impl Compiler {
             .unwrap_or_default();
         let mut ctx = FnCtx {
             locals: HashMap::new(),
-            local_count: params.len() as u32,
+            local_count: arity as u32,
             instructions: Vec::new(),
             compiler: self,
             loop_starts: Vec::new(),
@@ -1369,8 +1380,32 @@ impl Compiler {
             float_locals,
             string_locals,
         };
-        for (i, p) in params.iter().enumerate() {
-            ctx.locals.insert(p.clone(), i as u32);
+        // Bind params positionally; a list/tuple-pattern param destructures the
+        // (pair) argument via vec-get into named locals (`_` is a wildcard).
+        for (i, p) in param_exprs.iter().enumerate() {
+            match &p.kind {
+                ExprKind::Symbol(s) => {
+                    ctx.locals.insert(s.clone(), i as u32);
+                }
+                ExprKind::List(sub) | ExprKind::Tuple(sub) => {
+                    ctx.compiler.ensure_collections_runtime();
+                    let vget = ctx.compiler.collections_runtime.clone().unwrap().vec_get_idx;
+                    for (j, e) in sub.iter().enumerate() {
+                        if let ExprKind::Symbol(s) = &e.kind {
+                            if s == "_" {
+                                continue;
+                            }
+                            let l = ctx.alloc_local();
+                            ctx.instructions.push(WasmInstruction::LocalGet(i as u32));
+                            ctx.instructions.push(WasmInstruction::I64Const(j as i64));
+                            ctx.instructions.push(WasmInstruction::Call(vget));
+                            ctx.instructions.push(WasmInstruction::LocalSet(l));
+                            ctx.locals.insert(s.clone(), l);
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
         // Self-tail-recursion: a `recur` in the body (not inside a nested
         // `loop`) rebinds the params and jumps to the top. Wrap the body in a
@@ -1380,7 +1415,7 @@ impl Compiler {
             ctx.instructions
                 .push(WasmInstruction::Loop(BlockType::Result(ValType::I64)));
             ctx.loop_starts.push(ctx.instructions.len());
-            ctx.loop_vars.push((0..params.len() as u32).collect());
+            ctx.loop_vars.push((0..arity as u32).collect());
         }
         // Compile each body expression; every one leaves an i64 on the stack,
         // so drop all but the last (a statement sequence keeps only its final
@@ -1396,8 +1431,8 @@ impl Compiler {
             ctx.loop_starts.pop();
             ctx.loop_vars.pop();
         }
-        let extra_locals = if ctx.local_count > params.len() as u32 {
-            vec![ValType::I64; (ctx.local_count - params.len() as u32) as usize]
+        let extra_locals = if ctx.local_count > arity as u32 {
+            vec![ValType::I64; (ctx.local_count - arity as u32) as usize]
         } else {
             vec![]
         };
@@ -1410,7 +1445,7 @@ impl Compiler {
         self.push_function(
             func_idx,
             FunctionBody {
-                params: vec![ValType::I64; params.len()],
+                params: vec![ValType::I64; arity],
                 results: if is_main { vec![] } else { vec![ValType::I64] },
                 locals: extra_locals,
                 instructions: instrs,
@@ -2059,6 +2094,20 @@ impl<'a> FnCtx<'a> {
             }
             ExprKind::Vec(items) => {
                 // #[a b c] desugars to vec-new + a vec-push per element.
+                self.compiler.ensure_collections_runtime();
+                let rt = self.compiler.collections_runtime.clone().unwrap();
+                self.instructions
+                    .push(WasmInstruction::Call(rt.vec_new_idx));
+                for item in items {
+                    self.compile_expr(item)?;
+                    self.instructions
+                        .push(WasmInstruction::Call(rt.vec_push_idx));
+                }
+                Ok(())
+            }
+            ExprKind::Tuple(items) => {
+                // (a b …) — represented like a vector so destructuring and
+                // pair access (vec-get) work uniformly.
                 self.compiler.ensure_collections_runtime();
                 let rt = self.compiler.collections_runtime.clone().unwrap();
                 self.instructions
@@ -2925,6 +2974,14 @@ impl<'a> FnCtx<'a> {
                     }
                     return Err("codegen: fold requires init, function, collection".into());
                 }
+                "group-by" => {
+                    // [group-by f coll] -> map from f(elem) to a vector of the
+                    // elements with that key.
+                    if items.len() >= 3 {
+                        return self.compile_group_by(&items[1], &items[2]);
+                    }
+                    return Err("codegen: group-by requires function, collection".into());
+                }
                 "sort-by" => {
                     // [sort-by f order coll] — sort coll by integer key f(elem).
                     if items.len() >= 4 {
@@ -3778,6 +3835,78 @@ impl<'a> FnCtx<'a> {
         self.instructions.push(W::End);
         self.instructions.push(W::End);
         self.instructions.push(W::LocalGet(rl));
+        Ok(())
+    }
+    fn compile_group_by(&mut self, f: &Expr, coll: &Expr) -> Result<(), String> {
+        use WasmInstruction as W;
+        self.compiler.ensure_map_runtime();
+        let mr = self.compiler.map_runtime.clone().unwrap();
+        let cr = self.compiler.collections_runtime.clone().unwrap();
+        let fr = self.prepare_fn_arg(f)?;
+        self.compile_expr(coll)?;
+        let vl = self.alloc_local();
+        self.instructions.push(W::LocalSet(vl));
+        let (n, data) = self.emit_vec_header(vl);
+        let ml = self.alloc_local();
+        self.instructions.push(W::Call(mr.map_new_idx));
+        self.instructions.push(W::LocalSet(ml));
+        let iv = self.alloc_local();
+        let eloc = self.alloc_local();
+        let kloc = self.alloc_local();
+        let vecloc = self.alloc_local();
+        self.instructions.push(W::I64Const(0));
+        self.instructions.push(W::LocalSet(iv));
+        self.instructions.push(W::Block(BlockType::Empty));
+        self.instructions.push(W::Loop(BlockType::Empty));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::LocalGet(n));
+        self.instructions.push(W::I64LtS);
+        self.instructions.push(W::I32Eqz);
+        self.instructions.push(W::BrIf(1));
+        // elem = data[i]
+        self.instructions.push(W::LocalGet(data));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::I64Const(8));
+        self.instructions.push(W::I64Mul);
+        self.instructions.push(W::I64Add);
+        self.instructions.push(W::I32WrapI64);
+        self.instructions.push(W::I64Load(3, 0));
+        self.instructions.push(W::LocalSet(eloc));
+        // k = f(elem)
+        self.emit_apply1(&fr, eloc);
+        self.instructions.push(W::LocalSet(kloc));
+        // cur = map_get(m, k, 0); vec = (cur == 0 ? vec_new() : cur)
+        self.instructions.push(W::LocalGet(ml));
+        self.instructions.push(W::LocalGet(kloc));
+        self.instructions.push(W::I64Const(0));
+        self.instructions.push(W::Call(mr.map_get_idx));
+        self.instructions.push(W::LocalSet(vecloc));
+        self.instructions.push(W::LocalGet(vecloc));
+        self.instructions.push(W::I64Eqz);
+        self.instructions.push(W::If(BlockType::Result(ValType::I64)));
+        self.instructions.push(W::Call(cr.vec_new_idx));
+        self.instructions.push(W::Else);
+        self.instructions.push(W::LocalGet(vecloc));
+        self.instructions.push(W::End);
+        // vec2 = vec_push(vec, elem)
+        self.instructions.push(W::LocalGet(eloc));
+        self.instructions.push(W::Call(cr.vec_push_idx));
+        self.instructions.push(W::LocalSet(vecloc));
+        // m = map_set(m, k, vec2, 0)
+        self.instructions.push(W::LocalGet(ml));
+        self.instructions.push(W::LocalGet(kloc));
+        self.instructions.push(W::LocalGet(vecloc));
+        self.instructions.push(W::I64Const(0));
+        self.instructions.push(W::Call(mr.map_set_idx));
+        self.instructions.push(W::LocalSet(ml));
+        self.instructions.push(W::LocalGet(iv));
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::I64Add);
+        self.instructions.push(W::LocalSet(iv));
+        self.instructions.push(W::Br(0));
+        self.instructions.push(W::End);
+        self.instructions.push(W::End);
+        self.instructions.push(W::LocalGet(ml));
         Ok(())
     }
     fn compile_range(&mut self, a: &Expr, b: &Expr) -> Result<(), String> {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -2,11 +2,14 @@ mod capture;
 #[allow(clippy::vec_init_then_push)]
 pub mod collections;
 #[allow(clippy::vec_init_then_push)]
+pub mod maps;
+#[allow(clippy::vec_init_then_push)]
 pub mod strings;
 
 use crate::ast::{Expr, ExprKind, NodeId};
 use crate::types::Type;
 use collections::CollectionsRuntime;
+use maps::MapRuntime;
 use std::collections::HashMap;
 use strings::StringRuntime;
 use wasm_encoder::*;
@@ -101,6 +104,7 @@ struct Compiler {
     type_count: u32,
     string_runtime: Option<StringRuntime>,
     collections_runtime: Option<CollectionsRuntime>,
+    map_runtime: Option<MapRuntime>,
     base_dir: Option<std::path::PathBuf>,
     compiled_modules: std::collections::HashSet<std::path::PathBuf>,
     force_heap: bool,
@@ -465,6 +469,7 @@ impl Compiler {
             type_count: PRE_ALLOC_TYPES,
             string_runtime: None,
             collections_runtime: None,
+            map_runtime: None,
             base_dir: None,
             compiled_modules: std::collections::HashSet::new(),
             force_heap: false,
@@ -551,6 +556,42 @@ impl Compiler {
             vec_new_idx: n,
             vec_push_idx: p,
             vec_get_idx: g,
+        });
+    }
+    fn ensure_map_runtime(&mut self) {
+        if self.map_runtime.is_some() {
+            return;
+        }
+        self.force_heap = true;
+        // Maps reuse str_eq (string keys) and the vector runtime (for `keys`).
+        self.ensure_string_runtime();
+        let str_eq = self.string_runtime.clone().unwrap().str_eq_idx;
+        self.ensure_collections_runtime();
+        let cr = self.collections_runtime.clone().unwrap();
+        let new_idx = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(new_idx, MapRuntime::gen_map_new());
+        let set_idx = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(set_idx, MapRuntime::gen_map_set(str_eq));
+        let get_idx = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(get_idx, MapRuntime::gen_map_get(str_eq));
+        let has_idx = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(has_idx, MapRuntime::gen_map_has(str_eq));
+        let keys_idx = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(
+            keys_idx,
+            MapRuntime::gen_map_keys(cr.vec_new_idx, cr.vec_push_idx),
+        );
+        self.map_runtime = Some(MapRuntime {
+            map_new_idx: new_idx,
+            map_set_idx: set_idx,
+            map_get_idx: get_idx,
+            map_has_idx: has_idx,
+            map_keys_idx: keys_idx,
         });
     }
     fn compile_program(&mut self, exprs: &[Expr]) -> Result<(), String> {
@@ -1940,6 +1981,20 @@ impl<'a> FnCtx<'a> {
                 }
                 Ok(())
             }
+            ExprKind::Map(pairs) => {
+                // {:k v …} desugars to map-new + a map-set per pair.
+                self.compiler.ensure_map_runtime();
+                let rt = self.compiler.map_runtime.clone().unwrap();
+                self.instructions.push(WasmInstruction::Call(rt.map_new_idx));
+                for (k, v) in pairs {
+                    let is_str = self.expr_is_string(k) as i64;
+                    self.compile_expr(k)?;
+                    self.compile_expr(v)?;
+                    self.instructions.push(WasmInstruction::I64Const(is_str));
+                    self.instructions.push(WasmInstruction::Call(rt.map_set_idx));
+                }
+                Ok(())
+            }
             _ => Err(format!("codegen: unsupported expression: {:?}", expr.kind)),
         }
     }
@@ -2241,6 +2296,47 @@ impl<'a> FnCtx<'a> {
                     self.compile_expr(&items[2])?;
                     self.instructions
                         .push(WasmInstruction::Call(rt.vec_get_idx));
+                    return Ok(());
+                }
+                "assoc" => {
+                    // [assoc m k v] — copy-on-write insert; string keys use
+                    // structural equality (is_str flag).
+                    self.compiler.ensure_map_runtime();
+                    let rt = self.compiler.map_runtime.clone().unwrap();
+                    let is_str = self.expr_is_string(&items[2]) as i64;
+                    self.compile_expr(&items[1])?;
+                    self.compile_expr(&items[2])?;
+                    self.compile_expr(&items[3])?;
+                    self.instructions.push(WasmInstruction::I64Const(is_str));
+                    self.instructions.push(WasmInstruction::Call(rt.map_set_idx));
+                    return Ok(());
+                }
+                "get" => {
+                    // [get m k] — map lookup (UNIT if absent).
+                    self.compiler.ensure_map_runtime();
+                    let rt = self.compiler.map_runtime.clone().unwrap();
+                    let is_str = self.expr_is_string(&items[2]) as i64;
+                    self.compile_expr(&items[1])?;
+                    self.compile_expr(&items[2])?;
+                    self.instructions.push(WasmInstruction::I64Const(is_str));
+                    self.instructions.push(WasmInstruction::Call(rt.map_get_idx));
+                    return Ok(());
+                }
+                "contains?" | "has-key?" => {
+                    self.compiler.ensure_map_runtime();
+                    let rt = self.compiler.map_runtime.clone().unwrap();
+                    let is_str = self.expr_is_string(&items[2]) as i64;
+                    self.compile_expr(&items[1])?;
+                    self.compile_expr(&items[2])?;
+                    self.instructions.push(WasmInstruction::I64Const(is_str));
+                    self.instructions.push(WasmInstruction::Call(rt.map_has_idx));
+                    return Ok(());
+                }
+                "keys" => {
+                    self.compiler.ensure_map_runtime();
+                    let rt = self.compiler.map_runtime.clone().unwrap();
+                    self.compile_expr(&items[1])?;
+                    self.instructions.push(WasmInstruction::Call(rt.map_keys_idx));
                     return Ok(());
                 }
                 "first" => {
@@ -3360,6 +3456,19 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_maps_are_valid() {
+        // literals, assoc/get/contains?/keys, keyword + computed-string keys,
+        // and a fold building a frequency map (the word-count pattern).
+        valid(r#"[fn main [] [let m {:x 10 :y 20}] [println [get m :y]]]"#);
+        valid(r#"[fn main [] [let m [assoc {} "hi" 7]] [println [get m [str "h" "i"]]]]"#);
+        valid(r#"[fn main [] [let m {:a 1}] [println [if [contains? m :a] 1 0]]]"#);
+        valid(r#"[fn main [] [println [len [keys {:a 1 :b 2}]]]]"#);
+        valid(
+            r#"[fn add1 [m k] [assoc m k [+ [get m k] 1]]]
+               [fn main [] [let m [fold {} add1 #[5 5 7]]] [println [get m 5]]]"#,
+        );
     }
     #[test]
     fn compile_string_equality_is_structural() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -78,6 +78,11 @@ struct AdtInfo {
 
 const WASI_IMPORT_COUNT: u32 = 6;
 const PRE_ALLOC_TYPES: u32 = 7;
+/// Dynamic effect-handler stack, in low memory (below the string table at
+/// 1024 and the itoa scratch at ~520). `HANDLER_COUNT` holds the number of
+/// installed (op_id, closure) frames; each frame is 16 bytes from `HANDLER_BASE`.
+const HANDLER_COUNT_ADDR: i32 = 248;
+const HANDLER_BASE: i32 = 256;
 
 struct Compiler {
     functions: Vec<FunctionBody>,
@@ -110,6 +115,10 @@ struct Compiler {
     base_dir: Option<std::path::PathBuf>,
     compiled_modules: std::collections::HashSet<std::path::PathBuf>,
     force_heap: bool,
+    /// Force a (possibly empty) function table to exist. Effect operations emit
+    /// a `call_indirect` for the handler-closure path even when a program has no
+    /// closures of its own, and `call_indirect` requires a table.
+    force_table: bool,
     used_wasi_imports: Option<Vec<u32>>,
     /// Effect imports: "Effect.op" → import function index
     effect_imports: HashMap<String, u32>,
@@ -126,6 +135,9 @@ struct Compiler {
     /// Distinct keyword literals interned to unique i64 ids (for `=` and use as
     /// enum-like tags). Ids start high to avoid colliding with small ints.
     keywords: HashMap<String, i64>,
+    /// Distinct effect operations ("Effect.op") interned to small ids, used as
+    /// the key in the dynamic handler stack.
+    effect_op_ids: HashMap<String, i64>,
     /// Resolved type of each AST node (from the checker). Lets codegen make
     /// type-directed choices instead of guessing from syntax. Synthesized nodes
     /// (desugared `pipe`/`when`/… ) are absent and fall back to the untyped path.
@@ -213,6 +225,8 @@ enum WasmInstruction {
     I64Shl,
     I32And,
     I32Add,
+    I32Sub,
+    I32Mul,
     I32Load8U(u32, u32),
     I32Store8(u32, u32),
     I32Eq,
@@ -428,6 +442,12 @@ fn emit_instruction(f: &mut Function, instr: &WasmInstruction) {
         WasmInstruction::I32Add => {
             f.instruction(&Instruction::I32Add);
         }
+        WasmInstruction::I32Sub => {
+            f.instruction(&Instruction::I32Sub);
+        }
+        WasmInstruction::I32Mul => {
+            f.instruction(&Instruction::I32Mul);
+        }
         WasmInstruction::I32And => {
             f.instruction(&Instruction::I32And);
         }
@@ -482,6 +502,7 @@ impl Compiler {
             base_dir: None,
             compiled_modules: std::collections::HashSet::new(),
             force_heap: false,
+            force_table: false,
             used_wasi_imports: None,
             effect_imports: HashMap::new(),
             effect_import_defs: Vec::new(),
@@ -489,6 +510,7 @@ impl Compiler {
             string_fns: std::collections::HashSet::new(),
             string_params: HashMap::new(),
             keywords: HashMap::new(),
+            effect_op_ids: HashMap::new(),
             node_types: HashMap::new(),
             float_fns: std::collections::HashSet::new(),
             float_params: HashMap::new(),
@@ -506,6 +528,16 @@ impl Compiler {
         }
         let id = 0x4000_0000_0000_0000_i64 + self.keywords.len() as i64;
         self.keywords.insert(kw.to_string(), id);
+        id
+    }
+    /// Intern an effect operation key ("Effect.op") to a small positive id used
+    /// as the lookup key in the dynamic handler stack.
+    fn intern_effect_op(&mut self, key: &str) -> i64 {
+        if let Some(&id) = self.effect_op_ids.get(key) {
+            return id;
+        }
+        let id = self.effect_op_ids.len() as i64 + 1;
+        self.effect_op_ids.insert(key.to_string(), id);
         id
     }
     fn ensure_in_table(&mut self, func_idx: u32) -> u32 {
@@ -1577,12 +1609,13 @@ impl Compiler {
             functions.function(*idx);
         }
         module.section(&functions);
-        if !self.table_entries.is_empty() {
+        if !self.table_entries.is_empty() || self.force_table {
             let mut t = TableSection::new();
+            let n = self.table_entries.len() as u64;
             t.table(TableType {
                 element_type: RefType::FUNCREF,
-                minimum: self.table_entries.len() as u64,
-                maximum: Some(self.table_entries.len() as u64),
+                minimum: n,
+                maximum: Some(n),
                 table64: false,
                 shared: false,
             });
@@ -2895,11 +2928,34 @@ impl<'a> FnCtx<'a> {
                             self.compile_expr(arg)?;
                             self.emit_print_f64(nl);
                             return Ok(());
-                        } else {
-                            // A computed (non-literal) argument: evaluate it to
-                            // an i64 and print it as a decimal at runtime.
+                        } else if matches!(
+                            self.compiler.node_type(arg),
+                            Some(t) if !matches!(t, Type::Var(_))
+                        ) {
+                            // Statically a concrete non-string type: print as int.
                             self.compile_expr(arg)?;
                             self.emit_print_i64(nl);
+                            return Ok(());
+                        } else {
+                            // Unknown static type (e.g. a `handle` result): print
+                            // self-describingly — string bytes if it looks like a
+                            // string pointer at runtime, else a decimal int.
+                            use WasmInstruction as W;
+                            let x = self.alloc_local();
+                            self.compile_expr(arg)?;
+                            self.instructions.push(W::LocalSet(x));
+                            self.instructions.push(W::LocalGet(x));
+                            self.instructions.push(W::I64Const(32));
+                            self.instructions.push(W::I64ShrU);
+                            self.instructions.push(W::I64Const(1024));
+                            self.instructions.push(W::I64GeS);
+                            self.instructions.push(W::If(BlockType::Result(ValType::I64)));
+                            self.instructions.push(W::LocalGet(x));
+                            self.emit_print_str(nl);
+                            self.instructions.push(W::Else);
+                            self.instructions.push(W::LocalGet(x));
+                            self.emit_print_i64(nl);
+                            self.instructions.push(W::End);
                             return Ok(());
                         }
                     }
@@ -3034,16 +3090,28 @@ impl<'a> FnCtx<'a> {
                     self.instructions.push(WasmInstruction::I64Const(0));
                     return Ok(());
                 }
-                "handle" | "resume" | "try" => {
-                    // Delimited continuations need to capture and resume a stack
-                    // segment, which standalone wasm can't express without a
-                    // whole-program CPS/trampoline transform. These run on the
-                    // EIR VM (`loon run`) for now. Effect *operations*
-                    // (`E.op …`) still compile to host imports.
-                    return Err(format!(
-                        "codegen: '{s}' (delimited continuations) is not supported by the \
-                         wasm backend yet; run it on the VM with `loon run`"
-                    ));
+                "resume" => {
+                    // Tail-resumptive: `[resume v]` makes the effect operation
+                    // return v, so it compiles to just v (the handler closure's
+                    // return value becomes the op result). Non-tail / escaping
+                    // resume (the State pattern) is not supported here.
+                    if let Some(v) = items.get(1) {
+                        return self.compile_expr(v);
+                    }
+                    self.instructions.push(WasmInstruction::I64Const(0));
+                    return Ok(());
+                }
+                "handle" => {
+                    return self.compile_handle(&items[1..]);
+                }
+                "try" => {
+                    // Abort-style `try` needs non-local unwind across calls,
+                    // which standalone wasm can't express without exceptions or
+                    // a CPS transform. Run on the VM.
+                    return Err("codegen: 'try' (delimited continuations) is not \
+                                supported by the wasm backend yet; run it on the VM \
+                                with `loon run`"
+                        .into());
                 }
                 name => {
                     if let Some((tag, arity)) = self.compiler.adt_constructors.get(name).cloned() {
@@ -3076,16 +3144,205 @@ impl<'a> FnCtx<'a> {
         if let ExprKind::DotAccess(obj, op) = &items[0].kind {
             if let ExprKind::Symbol(effect) = &obj.kind {
                 if effect.starts_with(char::is_uppercase) {
-                    let import_idx = self.compiler.get_or_create_effect_import(effect, op);
-                    for arg in &items[1..] {
-                        self.compile_expr(arg)?;
-                    }
-                    self.instructions.push(WasmInstruction::Call(import_idx));
-                    return Ok(());
+                    return self.emit_effect_op(effect, op, &items[1..]);
                 }
             }
         }
         Err("codegen: unsupported call form".into())
+    }
+    /// Compile an effect operation `Effect.op args`. If a matching handler is
+    /// installed on the dynamic handler stack at runtime, call it (tail-
+    /// resumptive); otherwise fall back to the host import.
+    fn emit_effect_op(&mut self, effect: &str, op: &str, args: &[Expr]) -> Result<(), String> {
+        use WasmInstruction as W;
+        let key = format!("{effect}.{op}");
+        let op_id = self.compiler.intern_effect_op(&key);
+        let import_idx = self.compiler.get_or_create_effect_import(effect, op);
+        self.compiler.force_heap = true;
+        self.compiler.force_table = true; // the handler-closure path uses call_indirect
+        // Evaluate args into locals (reused by either call path).
+        let mut arglocs = Vec::new();
+        for a in args {
+            self.compile_expr(a)?;
+            let l = self.alloc_local();
+            self.instructions.push(W::LocalSet(l));
+            arglocs.push(l);
+        }
+        // Scan the handler stack top-down for op_id. Track `found` separately:
+        // a capture-less closure value can legitimately be 0 (table index 0).
+        let cl = self.alloc_local();
+        let found = self.alloc_local();
+        let f = self.alloc_local();
+        self.instructions.push(W::I64Const(0));
+        self.instructions.push(W::LocalSet(cl));
+        self.instructions.push(W::I64Const(0));
+        self.instructions.push(W::LocalSet(found));
+        // f = count - 1
+        self.instructions.push(W::I32Const(HANDLER_COUNT_ADDR));
+        self.instructions.push(W::I32Load(2, 0));
+        self.instructions.push(W::I64ExtendI32U);
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::I64Sub);
+        self.instructions.push(W::LocalSet(f));
+        self.instructions.push(W::Block(BlockType::Empty));
+        self.instructions.push(W::Loop(BlockType::Empty));
+        self.instructions.push(W::LocalGet(f));
+        self.instructions.push(W::I64Const(0));
+        self.instructions.push(W::I64LtS);
+        self.instructions.push(W::BrIf(1)); // f < 0: not found
+        // addr = HANDLER_BASE + f*16  (kept as i64; wrapped at memory ops)
+        let addr = self.alloc_local();
+        self.instructions.push(W::LocalGet(f));
+        self.instructions.push(W::I64Const(16));
+        self.instructions.push(W::I64Mul);
+        self.instructions.push(W::I64Const(HANDLER_BASE as i64));
+        self.instructions.push(W::I64Add);
+        self.instructions.push(W::LocalSet(addr));
+        // entry op_id == op_id ?
+        self.instructions.push(W::LocalGet(addr));
+        self.instructions.push(W::I32WrapI64);
+        self.instructions.push(W::I64Load(3, 0));
+        self.instructions.push(W::I64Const(op_id));
+        self.instructions.push(W::I64Eq);
+        self.instructions.push(W::If(BlockType::Empty));
+        self.instructions.push(W::LocalGet(addr));
+        self.instructions.push(W::I32WrapI64);
+        self.instructions.push(W::I64Load(3, 8));
+        self.instructions.push(W::LocalSet(cl));
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::LocalSet(found));
+        self.instructions.push(W::Br(2)); // found: exit scan
+        self.instructions.push(W::End);
+        self.instructions.push(W::LocalGet(f));
+        self.instructions.push(W::I64Const(1));
+        self.instructions.push(W::I64Sub);
+        self.instructions.push(W::LocalSet(f));
+        self.instructions.push(W::Br(0));
+        self.instructions.push(W::End);
+        self.instructions.push(W::End);
+        // if !found: import(args) else closure(env, args) via the table.
+        self.instructions.push(W::LocalGet(found));
+        self.instructions.push(W::I64Eqz);
+        self.instructions.push(W::If(BlockType::Result(ValType::I64)));
+        for &l in &arglocs {
+            self.instructions.push(W::LocalGet(l));
+        }
+        self.instructions.push(W::Call(import_idx));
+        self.instructions.push(W::Else);
+        // env = cl & 0xffffffff
+        self.instructions.push(W::LocalGet(cl));
+        self.instructions.push(W::I64Const(0xFFFF_FFFF));
+        self.instructions.push(W::I64And);
+        for &l in &arglocs {
+            self.instructions.push(W::LocalGet(l));
+        }
+        self.instructions.push(W::LocalGet(cl));
+        self.instructions.push(W::I64Const(32));
+        self.instructions.push(W::I64ShrU);
+        self.instructions.push(W::I32WrapI64);
+        let ty = self.get_or_create_indirect_type(1 + arglocs.len());
+        self.instructions.push(W::CallIndirect(ty));
+        self.instructions.push(W::End);
+        Ok(())
+    }
+    /// Compile `[handle body clause…]` for tail-resumptive handlers. Each
+    /// `[E.op params] hbody` clause installs a handler closure on the dynamic
+    /// stack for the duration of `body`; a `[return x]` clause post-processes
+    /// the body's value.
+    fn compile_handle(&mut self, args: &[Expr]) -> Result<(), String> {
+        use WasmInstruction as W;
+        if args.is_empty() {
+            self.instructions.push(W::I64Const(0));
+            return Ok(());
+        }
+        let body = &args[0];
+        let clauses = &args[1..];
+        self.compiler.force_heap = true;
+        let mut return_clause: Option<(String, &Expr)> = None;
+        let mut pushed = 0i32;
+        let mut i = 0;
+        while i + 1 < clauses.len() {
+            let pat = &clauses[i];
+            let hbody = &clauses[i + 1];
+            i += 2;
+            let parts = match &pat.kind {
+                ExprKind::List(p) if !p.is_empty() => p,
+                _ => continue,
+            };
+            // [return x] clause
+            if let ExprKind::Symbol(s) = &parts[0].kind {
+                if s == "return" {
+                    if let Some(ExprKind::Symbol(x)) = parts.get(1).map(|e| &e.kind) {
+                        return_clause = Some((x.clone(), hbody));
+                    }
+                    continue;
+                }
+            }
+            // [E.op params…] clause
+            if let ExprKind::DotAccess(obj, op) = &parts[0].kind {
+                if let ExprKind::Symbol(effect) = &obj.kind {
+                    let key = format!("{effect}.{op}");
+                    let op_id = self.compiler.intern_effect_op(&key);
+                    // handler closure: [fn [params…] hbody]
+                    let sp = pat.span;
+                    let params_list =
+                        Expr::new(ExprKind::List(parts[1..].to_vec()), sp);
+                    self.compile_closure(&[params_list, hbody.clone()])?;
+                    let cval = self.alloc_local();
+                    self.instructions.push(W::LocalSet(cval));
+                    // cnt = count (kept as i64); addr = HANDLER_BASE + cnt*16
+                    let cnt = self.alloc_local();
+                    self.instructions.push(W::I32Const(HANDLER_COUNT_ADDR));
+                    self.instructions.push(W::I32Load(2, 0));
+                    self.instructions.push(W::I64ExtendI32U);
+                    self.instructions.push(W::LocalSet(cnt));
+                    let addr = self.alloc_local();
+                    self.instructions.push(W::LocalGet(cnt));
+                    self.instructions.push(W::I64Const(16));
+                    self.instructions.push(W::I64Mul);
+                    self.instructions.push(W::I64Const(HANDLER_BASE as i64));
+                    self.instructions.push(W::I64Add);
+                    self.instructions.push(W::LocalSet(addr));
+                    // mem[addr] = op_id ; mem[addr+8] = cval
+                    self.instructions.push(W::LocalGet(addr));
+                    self.instructions.push(W::I32WrapI64);
+                    self.instructions.push(W::I64Const(op_id));
+                    self.instructions.push(W::I64Store(3, 0));
+                    self.instructions.push(W::LocalGet(addr));
+                    self.instructions.push(W::I32WrapI64);
+                    self.instructions.push(W::LocalGet(cval));
+                    self.instructions.push(W::I64Store(3, 8));
+                    // count += 1
+                    self.instructions.push(W::I32Const(HANDLER_COUNT_ADDR));
+                    self.instructions.push(W::LocalGet(cnt));
+                    self.instructions.push(W::I32WrapI64);
+                    self.instructions.push(W::I32Const(1));
+                    self.instructions.push(W::I32Add);
+                    self.instructions.push(W::I32Store(2, 0));
+                    pushed += 1;
+                }
+            }
+        }
+        // Compile the body, then pop the installed frames.
+        self.compile_expr(body)?;
+        let bodyval = self.alloc_local();
+        self.instructions.push(W::LocalSet(bodyval));
+        if pushed > 0 {
+            self.instructions.push(W::I32Const(HANDLER_COUNT_ADDR));
+            self.instructions.push(W::I32Const(HANDLER_COUNT_ADDR));
+            self.instructions.push(W::I32Load(2, 0));
+            self.instructions.push(W::I32Const(pushed));
+            self.instructions.push(W::I32Sub);
+            self.instructions.push(W::I32Store(2, 0));
+        }
+        // Apply the [return x] clause, if any.
+        if let Some((x, hbody)) = return_clause {
+            self.locals.insert(x, bodyval);
+            self.compile_expr(hbody)?;
+        } else {
+            self.instructions.push(W::LocalGet(bodyval));
+        }
+        Ok(())
     }
     fn compile_match_arms(&mut self, scrutinee: u32, arms: &[Expr]) -> Result<(), String> {
         let parsed = self.parse_arms(arms);
@@ -4500,6 +4757,22 @@ mod tests {
         assert!(
             wasm_str.contains("read-file"),
             "should contain effect op name"
+        );
+    }
+    #[test]
+    fn compile_tail_resumptive_handlers_are_valid() {
+        // A handler that `resume`s in tail position is installed on the dynamic
+        // handler stack and intercepts the op (even through a function call).
+        valid(
+            r#"[effect Log [ask [] Int]]
+               [fn use-log [] [+ [Log.ask] 1]]
+               [fn main [] [println [handle [use-log] [Log.ask] [resume 41]]]]"#,
+        );
+        // `[return x]` clause and multiple ops.
+        valid(
+            r#"[effect E [a [] Int] [b [] Int]]
+               [fn main [] [println [handle [+ [E.a] [E.b]]
+                 [return x] [* x 2] [E.a] [resume 10] [E.b] [resume 20]]]]"#,
         );
     }
     #[test]

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -2429,6 +2429,36 @@ impl<'a> FnCtx<'a> {
                     self.instructions.push(WasmInstruction::Call(rt.map_set_idx));
                     return Ok(());
                 }
+                "update" => {
+                    // [update m k f] = assoc m k (f (get m k)).
+                    self.compiler.ensure_map_runtime();
+                    let rt = self.compiler.map_runtime.clone().unwrap();
+                    let fr = self.prepare_fn_arg(&items[3])?;
+                    let ml = self.alloc_local();
+                    self.compile_expr(&items[1])?;
+                    self.instructions.push(WasmInstruction::LocalSet(ml));
+                    let kl = self.alloc_local();
+                    self.compile_expr(&items[2])?;
+                    self.instructions.push(WasmInstruction::LocalSet(kl));
+                    // cur = map_get(m, k, 0)
+                    let curl = self.alloc_local();
+                    self.instructions.push(WasmInstruction::LocalGet(ml));
+                    self.instructions.push(WasmInstruction::LocalGet(kl));
+                    self.instructions.push(WasmInstruction::I64Const(0));
+                    self.instructions.push(WasmInstruction::Call(rt.map_get_idx));
+                    self.instructions.push(WasmInstruction::LocalSet(curl));
+                    // newv = f(cur)
+                    let newv = self.alloc_local();
+                    self.emit_apply1(&fr, curl);
+                    self.instructions.push(WasmInstruction::LocalSet(newv));
+                    // map_set(m, k, newv, 0)
+                    self.instructions.push(WasmInstruction::LocalGet(ml));
+                    self.instructions.push(WasmInstruction::LocalGet(kl));
+                    self.instructions.push(WasmInstruction::LocalGet(newv));
+                    self.instructions.push(WasmInstruction::I64Const(0));
+                    self.instructions.push(WasmInstruction::Call(rt.map_set_idx));
+                    return Ok(());
+                }
                 "get" => {
                     // [get m k] — map lookup (UNIT if absent).
                     self.compiler.ensure_map_runtime();
@@ -3635,6 +3665,14 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_update_is_valid() {
+        valid(r#"[fn main [] [println [get [update {:a 5} :a [fn [n] [+ n 10]]] :a]]]"#);
+        valid(
+            r#"[fn bump [m k] [update m k [fn [n] [+ [or n 0] 1]]]]
+               [fn main [] [println [get [fold {} bump [split "a b a" " "]] "a"]]]"#,
+        );
     }
     #[test]
     fn compile_take_is_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -119,6 +119,9 @@ struct Compiler {
     /// a `call_indirect` for the handler-closure path even when a program has no
     /// closures of its own, and `call_indirect` requires a table.
     force_table: bool,
+    /// Whether the program uses abort (`Fail.fail`/`try`), which lowers to a
+    /// WASM exception: a `fail` tag carrying the i64 fail value.
+    uses_exceptions: bool,
     used_wasi_imports: Option<Vec<u32>>,
     /// Effect imports: "Effect.op" → import function index
     effect_imports: HashMap<String, u32>,
@@ -236,6 +239,10 @@ enum WasmInstruction {
     Br(u32),
     BrIf(u32),
     BrTable(Vec<u32>, u32),
+    /// Exception support (abort): throw the `fail` tag (index 0), and a
+    /// try_table whose single catch routes the `fail` tag to `catch_label`.
+    Throw,
+    TryTable { catch_label: u32 },
 }
 
 fn emit_instruction(f: &mut Function, instr: &WasmInstruction) {
@@ -475,6 +482,18 @@ fn emit_instruction(f: &mut Function, instr: &WasmInstruction) {
                 *default,
             ));
         }
+        WasmInstruction::Throw => {
+            f.instruction(&Instruction::Throw(0)); // the `fail` tag
+        }
+        WasmInstruction::TryTable { catch_label } => {
+            f.instruction(&Instruction::TryTable(
+                BlockType::Result(ValType::I64),
+                std::borrow::Cow::Owned(vec![Catch::One {
+                    tag: 0,
+                    label: *catch_label,
+                }]),
+            ));
+        }
     }
 }
 
@@ -503,6 +522,7 @@ impl Compiler {
             compiled_modules: std::collections::HashSet::new(),
             force_heap: false,
             force_table: false,
+            uses_exceptions: false,
             used_wasi_imports: None,
             effect_imports: HashMap::new(),
             effect_import_defs: Vec::new(),
@@ -1564,6 +1584,11 @@ impl Compiler {
                 .ty()
                 .function(vec![ValType::I64; *arity], vec![ValType::I64]);
         }
+        // Type for the `fail` exception tag: (i64) -> ().
+        let fail_type_idx = types.len();
+        if self.uses_exceptions {
+            types.ty().function(vec![ValType::I64], vec![]);
+        }
         module.section(&types);
         let wasi_defs: [(u32, &str, u32); 6] = [
             (0, "fd_write", 0),
@@ -1634,6 +1659,15 @@ impl Compiler {
             page_size_log2: None,
         });
         module.section(&mem);
+        // Tag section (id 13) goes between memory and global.
+        if self.uses_exceptions {
+            let mut tags = TagSection::new();
+            tags.tag(TagType {
+                kind: TagKind::Exception,
+                func_type_idx: fail_type_idx,
+            });
+            module.section(&tags);
+        }
         if self.force_heap || !self.table_entries.is_empty() || !self.adt_constructors.is_empty() {
             let mut g = GlobalSection::new();
             g.global(
@@ -3105,13 +3139,28 @@ impl<'a> FnCtx<'a> {
                     return self.compile_handle(&items[1..]);
                 }
                 "try" => {
-                    // Abort-style `try` needs non-local unwind across calls,
-                    // which standalone wasm can't express without exceptions or
-                    // a CPS transform. Run on the VM.
-                    return Err("codegen: 'try' (delimited continuations) is not \
-                                supported by the wasm backend yet; run it on the VM \
-                                with `loon run`"
-                        .into());
+                    // [try expr handler] — run expr; if it raises `fail`
+                    // (Fail.fail), apply handler to the failure value. Lowers to
+                    // a wasm exception try_table.
+                    use WasmInstruction as W;
+                    self.compiler.uses_exceptions = true;
+                    let fr = self.prepare_fn_arg(&items[2])?;
+                    self.instructions
+                        .push(W::Block(BlockType::Result(ValType::I64))); // $done
+                    self.instructions
+                        .push(W::Block(BlockType::Result(ValType::I64))); // $onfail
+                    // The catch label is resolved in the context enclosing the
+                    // try_table, so $onfail is label 0 here.
+                    self.instructions.push(W::TryTable { catch_label: 0 }); // catch fail -> $onfail
+                    self.compile_expr(&items[1])?;
+                    self.instructions.push(W::End); // try_table
+                    self.instructions.push(W::Br(1)); // normal: result -> $done
+                    self.instructions.push(W::End); // $onfail: fail value on stack
+                    let fv = self.alloc_local();
+                    self.instructions.push(W::LocalSet(fv));
+                    self.emit_apply1(&fr, fv); // handler(failval) -> $done
+                    self.instructions.push(W::End); // $done
+                    return Ok(());
                 }
                 name => {
                     if let Some((tag, arity)) = self.compiler.adt_constructors.get(name).cloned() {
@@ -3155,6 +3204,19 @@ impl<'a> FnCtx<'a> {
     /// resumptive); otherwise fall back to the host import.
     fn emit_effect_op(&mut self, effect: &str, op: &str, args: &[Expr]) -> Result<(), String> {
         use WasmInstruction as W;
+        // Abort: `Fail.fail v` raises the `fail` exception (caught by `try`).
+        if effect == "Fail" && op == "fail" {
+            self.compiler.uses_exceptions = true;
+            if let Some(a) = args.first() {
+                self.compile_expr(a)?;
+            } else {
+                self.instructions.push(WasmInstruction::I64Const(0));
+            }
+            self.instructions.push(WasmInstruction::Throw);
+            // Unreachable after throw, but keep the "leaves i64" contract.
+            self.instructions.push(WasmInstruction::I64Const(0));
+            return Ok(());
+        }
         let key = format!("{effect}.{op}");
         let op_id = self.compiler.intern_effect_op(&key);
         let import_idx = self.compiler.get_or_create_effect_import(effect, op);
@@ -4757,6 +4819,21 @@ mod tests {
         assert!(
             wasm_str.contains("read-file"),
             "should contain effect op name"
+        );
+    }
+    #[test]
+    fn compile_try_abort_is_valid() {
+        // Abort via wasm exceptions: Fail.fail raises, try catches & handles.
+        valid(
+            r#"[effect Fail [fail [Int] Int]]
+               [fn risky [n] [if [> n 5] [Fail.fail n] n]]
+               [fn main [] [println [try [risky 10] [fn [msg] [+ msg 100]]]]]"#,
+        );
+        // Recursive abort handling (the tco-stress pattern).
+        valid(
+            r#"[effect Fail [fail [Int] Int]]
+               [fn down [n] [if [= n 0] 999 [try [Fail.fail n] [fn [m] [down [- m 1]]]]]]
+               [fn main [] [println [down 5]]]"#,
         );
     }
     #[test]

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -105,6 +105,8 @@ struct Compiler {
     string_runtime: Option<StringRuntime>,
     collections_runtime: Option<CollectionsRuntime>,
     map_runtime: Option<MapRuntime>,
+    /// Lazily-generated `str_split` (needs both string + vector runtimes).
+    str_split_idx: Option<u32>,
     base_dir: Option<std::path::PathBuf>,
     compiled_modules: std::collections::HashSet<std::path::PathBuf>,
     force_heap: bool,
@@ -119,6 +121,8 @@ struct Compiler {
     /// string. Lets `println` pick the string-printing path for calls, since
     /// the untagged value model offers no runtime check.
     string_fns: std::collections::HashSet<String>,
+    /// For each function key, the names of its string-typed parameters.
+    string_params: HashMap<String, Vec<String>>,
     /// Distinct keyword literals interned to unique i64 ids (for `=` and use as
     /// enum-like tags). Ids start high to avoid colliding with small ints.
     keywords: HashMap<String, i64>,
@@ -470,6 +474,7 @@ impl Compiler {
             string_runtime: None,
             collections_runtime: None,
             map_runtime: None,
+            str_split_idx: None,
             base_dir: None,
             compiled_modules: std::collections::HashSet::new(),
             force_heap: false,
@@ -478,6 +483,7 @@ impl Compiler {
             effect_import_defs: Vec::new(),
             effect_registry: crate::effects::EffectRegistry::new(),
             string_fns: std::collections::HashSet::new(),
+            string_params: HashMap::new(),
             keywords: HashMap::new(),
             node_types: HashMap::new(),
             float_fns: std::collections::HashSet::new(),
@@ -594,6 +600,24 @@ impl Compiler {
             map_keys_idx: keys_idx,
         });
     }
+    fn ensure_split_runtime(&mut self) -> u32 {
+        if let Some(idx) = self.str_split_idx {
+            return idx;
+        }
+        self.force_heap = true;
+        self.ensure_string_runtime();
+        let substr = self.string_runtime.clone().unwrap().str_substring_idx;
+        self.ensure_collections_runtime();
+        let cr = self.collections_runtime.clone().unwrap();
+        let idx = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(
+            idx,
+            StringRuntime::gen_str_split(cr.vec_new_idx, cr.vec_push_idx, substr),
+        );
+        self.str_split_idx = Some(idx);
+        idx
+    }
     fn compile_program(&mut self, exprs: &[Expr]) -> Result<(), String> {
         // Pass 0: collect [effect ...] declarations
         for expr in exprs {
@@ -686,8 +710,7 @@ impl Compiler {
                 }
             }
         }
-        self.analyze_string_fns(exprs);
-        self.analyze_floats(exprs);
+        self.analyze_types(exprs);
         for expr in exprs {
             if let ExprKind::List(items) = &expr.kind {
                 if items.len() >= 3 {
@@ -702,52 +725,6 @@ impl Compiler {
             }
         }
         Ok(())
-    }
-    /// Compute, to a fixpoint, which functions statically return a string, so
-    /// `println` can route their call results through the byte-printing path.
-    fn analyze_string_fns(&mut self, exprs: &[Expr]) {
-        // Collect (fn key, return expression) for every clause.
-        let mut returns: Vec<(String, &Expr)> = Vec::new();
-        for expr in exprs {
-            if let ExprKind::List(items) = &expr.kind {
-                if items.len() >= 3 && matches!(&items[0].kind, ExprKind::Symbol(s) if s == "fn") {
-                    if let ExprKind::Symbol(name) = &items[1].kind {
-                        let args = &items[1..];
-                        if Self::is_multi_arity(args) {
-                            for clause in &args[1..] {
-                                if let ExprKind::Tuple(parts) = &clause.kind {
-                                    if let (Some(ExprKind::List(params)), Some(last)) =
-                                        (parts.first().map(|e| &e.kind), parts.last())
-                                    {
-                                        if parts.len() >= 2 {
-                                            let key =
-                                                format!("{name}#{}", Self::param_names(params).len());
-                                            returns.push((key, last));
-                                        }
-                                    }
-                                }
-                            }
-                        } else if let Some(last) = items.last() {
-                            returns.push((name.clone(), last));
-                        }
-                    }
-                }
-            }
-        }
-        loop {
-            let mut changed = false;
-            for (key, ret) in &returns {
-                if !self.string_fns.contains(key)
-                    && Self::expr_returns_string(ret, &self.string_fns)
-                {
-                    self.string_fns.insert(key.clone());
-                    changed = true;
-                }
-            }
-            if !changed {
-                break;
-            }
-        }
     }
     /// Structural float check: whether `e` evaluates to a float, given the set
     /// of in-scope float-named bindings and the known float-returning functions.
@@ -808,7 +785,7 @@ impl Compiler {
     /// Whole-program fixpoint recovering which functions return floats and which
     /// of their parameters are float. The checker generalizes polymorphic
     /// bodies, so this structural pass fills the gap for monomorphic float use.
-    fn analyze_floats(&mut self, exprs: &[Expr]) {
+    fn analyze_types(&mut self, exprs: &[Expr]) {
         // fn key -> param names; and (key, last body expr) per clause.
         let mut fn_params: HashMap<String, Vec<String>> = HashMap::new();
         let mut fn_bodies: Vec<(String, &Expr)> = Vec::new();
@@ -882,18 +859,43 @@ impl Compiler {
                 }
             }
         }
-        let mut float_fns: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let mut float_params: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
+        // Run the same return/param fixpoint for floats and for strings, using
+        // the matching structural predicate.
+        let (float_fns, float_params) =
+            Self::propagate_type(&fn_bodies, &calls, &fn_params, Self::is_float_static);
+        self.float_fns = float_fns;
+        self.float_params = float_params;
+        let (string_fns, string_params) =
+            Self::propagate_type(&fn_bodies, &calls, &fn_params, Self::is_str_static);
+        self.string_fns = string_fns;
+        self.string_params = string_params;
+    }
+    /// Generic whole-program fixpoint: given a structural predicate `pred` that
+    /// decides whether an expression is of the type in question (consulting the
+    /// in-scope names + the set of functions returning that type), compute which
+    /// functions return that type and which of their params carry it.
+    #[allow(clippy::type_complexity)]
+    fn propagate_type(
+        fn_bodies: &[(String, &Expr)],
+        calls: &[(Option<String>, String, Vec<&Expr>)],
+        fn_params: &HashMap<String, Vec<String>>,
+        pred: fn(&Expr, &std::collections::HashSet<String>, &std::collections::HashSet<String>) -> bool,
+    ) -> (
+        std::collections::HashSet<String>,
+        HashMap<String, Vec<String>>,
+    ) {
+        let mut ret_fns: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut params: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
         loop {
             let mut changed = false;
-            for (key, last) in &fn_bodies {
-                let names = float_params.get(key).cloned().unwrap_or_default();
-                if !float_fns.contains(key) && Self::is_float_static(last, &names, &float_fns) {
-                    float_fns.insert(key.clone());
+            for (key, last) in fn_bodies {
+                let names = params.get(key).cloned().unwrap_or_default();
+                if !ret_fns.contains(key) && pred(last, &names, &ret_fns) {
+                    ret_fns.insert(key.clone());
                     changed = true;
                 }
             }
-            for (enc, callee, args) in &calls {
+            for (enc, callee, args) in calls {
                 let callee_key = if fn_params.contains_key(callee) {
                     callee.clone()
                 } else {
@@ -906,7 +908,7 @@ impl Compiler {
                 };
                 let enc_names = enc
                     .as_ref()
-                    .and_then(|k| float_params.get(k))
+                    .and_then(|k| params.get(k))
                     .cloned()
                     .unwrap_or_default();
                 let pnames = fn_params[&callee_key].clone();
@@ -914,8 +916,8 @@ impl Compiler {
                     if i >= pnames.len() {
                         break;
                     }
-                    if Self::is_float_static(arg, &enc_names, &float_fns) {
-                        let set = float_params.entry(callee_key.clone()).or_default();
+                    if pred(arg, &enc_names, &ret_fns) {
+                        let set = params.entry(callee_key.clone()).or_default();
                         if set.insert(pnames[i].clone()) {
                             changed = true;
                         }
@@ -926,35 +928,54 @@ impl Compiler {
                 break;
             }
         }
-        self.float_fns = float_fns;
-        self.float_params = float_params
+        let params = params
             .into_iter()
             .map(|(k, v)| (k, v.into_iter().collect()))
             .collect();
+        (ret_fns, params)
     }
-    /// Whether an expression statically evaluates to a string, consulting the
-    /// set of known string-returning functions for calls. Conservative.
-    fn expr_returns_string(expr: &Expr, fns: &std::collections::HashSet<String>) -> bool {
-        match &expr.kind {
+    /// Structural string check (mirrors `is_float_static`): whether `e`
+    /// evaluates to a string, given in-scope string-named bindings and the set
+    /// of known string-returning functions.
+    fn is_str_static(
+        e: &Expr,
+        strs: &std::collections::HashSet<String>,
+        string_fns: &std::collections::HashSet<String>,
+    ) -> bool {
+        match &e.kind {
             ExprKind::Str(_) => true,
-            ExprKind::List(items) => match items.first().map(|e| &e.kind) {
-                Some(ExprKind::Symbol(s)) => match s.as_str() {
-                    "str" | "str-concat" | "substring" => true,
-                    "do" => items.last().is_some_and(|e| Self::expr_returns_string(e, fns)),
-                    "if" => {
-                        items.len() >= 4
-                            && Self::expr_returns_string(&items[2], fns)
-                            && Self::expr_returns_string(&items[3], fns)
+            ExprKind::Symbol(s) => strs.contains(s),
+            ExprKind::List(items) if !items.is_empty() => {
+                if let ExprKind::Symbol(h) = &items[0].kind {
+                    let argc = items.len() - 1;
+                    match h.as_str() {
+                        "str" | "str-concat" | "substring" => true,
+                        "do" => items
+                            .last()
+                            .is_some_and(|e| Self::is_str_static(e, strs, string_fns)),
+                        "if" if argc >= 3 => {
+                            Self::is_str_static(&items[2], strs, string_fns)
+                                || Self::is_str_static(&items[3], strs, string_fns)
+                        }
+                        "match" if argc >= 3 => {
+                            let mut i = 3;
+                            while i < items.len() {
+                                if Self::is_str_static(&items[i], strs, string_fns) {
+                                    return true;
+                                }
+                                i += 2;
+                            }
+                            false
+                        }
+                        _ => {
+                            string_fns.contains(h.as_str())
+                                || string_fns.contains(&format!("{h}#{argc}"))
+                        }
                     }
-                    // A call: string iff the callee (by name or arity) is known
-                    // to return a string.
-                    name => {
-                        let argc = items.len() - 1;
-                        fns.contains(name) || fns.contains(&format!("{name}#{argc}"))
-                    }
-                },
-                _ => false,
-            },
+                } else {
+                    false
+                }
+            }
             _ => false,
         }
     }
@@ -1308,9 +1329,14 @@ impl Compiler {
         params: &[String],
         body: &[Expr],
     ) -> Result<(), String> {
-        // Params known to be float (from the float fixpoint) seed float_locals.
+        // Params known to be float/string (from the fixpoint) seed the locals.
         let float_locals: std::collections::HashSet<String> = self
             .float_params
+            .get(key)
+            .map(|v| v.iter().cloned().collect())
+            .unwrap_or_default();
+        let string_locals: std::collections::HashSet<String> = self
+            .string_params
             .get(key)
             .map(|v| v.iter().cloned().collect())
             .unwrap_or_default();
@@ -1322,6 +1348,7 @@ impl Compiler {
             loop_starts: Vec::new(),
             loop_vars: Vec::new(),
             float_locals,
+            string_locals,
         };
         for (i, p) in params.iter().enumerate() {
             ctx.locals.insert(p.clone(), i as u32);
@@ -1588,6 +1615,9 @@ struct FnCtx<'a> {
     /// Names of in-scope bindings (params + lets) known to hold float values,
     /// so arithmetic on them picks the f64 path.
     float_locals: std::collections::HashSet<String>,
+    /// Names of in-scope bindings known to hold string values, so `=`/map keys/
+    /// `println` pick the string path.
+    string_locals: std::collections::HashSet<String>,
 }
 
 impl<'a> FnCtx<'a> {
@@ -1845,12 +1875,14 @@ impl<'a> FnCtx<'a> {
     /// pick the string-printing path when it can prove the argument is a
     /// string at compile time.
     fn expr_is_string(&self, expr: &Expr) -> bool {
-        // Type-directed: trust the checker's resolved type when it has one.
-        if let Some(ty) = self.compiler.node_type(expr) {
-            return matches!(ty, Type::Str);
+        match self.compiler.node_type(expr) {
+            Some(Type::Str) => return true,
+            // A concrete non-string type is authoritative.
+            Some(t) if !matches!(t, Type::Var(_)) => return false,
+            _ => {}
         }
-        // Fallback for synthesized nodes (desugared forms) the checker never saw.
-        Compiler::expr_returns_string(expr, &self.compiler.string_fns)
+        // Generalized/synthesized nodes: structural fallback.
+        Compiler::is_str_static(expr, &self.string_locals, &self.compiler.string_fns)
     }
     /// Whether an expression is statically of float type. Trusts the checker's
     /// concrete type when present; otherwise falls back to a structural check
@@ -2282,6 +2314,70 @@ impl<'a> FnCtx<'a> {
                         .push(WasmInstruction::Call(rt.vec_push_idx));
                     return Ok(());
                 }
+                "split" => {
+                    // [split s sep] -> vector of substrings (sep is one char).
+                    let idx = self.compiler.ensure_split_runtime();
+                    self.compile_expr(&items[1])?;
+                    self.compile_expr(&items[2])?;
+                    self.instructions.push(WasmInstruction::Call(idx));
+                    return Ok(());
+                }
+                "cons" => {
+                    // [cons x v] -> new vector with x prepended.
+                    self.compiler.ensure_collections_runtime();
+                    let rt = self.compiler.collections_runtime.clone().unwrap();
+                    let xl = self.alloc_local();
+                    self.compile_expr(&items[1])?;
+                    self.instructions.push(WasmInstruction::LocalSet(xl));
+                    self.compile_expr(&items[2])?;
+                    let vl = self.alloc_local();
+                    self.instructions.push(WasmInstruction::LocalSet(vl));
+                    // r = vec_push(vec_new(), x)
+                    self.instructions
+                        .push(WasmInstruction::Call(rt.vec_new_idx));
+                    self.instructions.push(WasmInstruction::LocalGet(xl));
+                    self.instructions
+                        .push(WasmInstruction::Call(rt.vec_push_idx));
+                    let rl = self.alloc_local();
+                    self.instructions.push(WasmInstruction::LocalSet(rl));
+                    // append each element of v
+                    let (n, d) = self.emit_vec_header(vl);
+                    let iv = self.alloc_local();
+                    let el = self.alloc_local();
+                    use WasmInstruction as W;
+                    self.instructions.push(W::I64Const(0));
+                    self.instructions.push(W::LocalSet(iv));
+                    self.instructions.push(W::Block(BlockType::Empty));
+                    self.instructions.push(W::Loop(BlockType::Empty));
+                    self.instructions.push(W::LocalGet(iv));
+                    self.instructions.push(W::LocalGet(n));
+                    self.instructions.push(W::I64LtS);
+                    self.instructions.push(W::I32Eqz);
+                    self.instructions.push(W::BrIf(1));
+                    // el = d[iv]
+                    self.instructions.push(W::LocalGet(d));
+                    self.instructions.push(W::LocalGet(iv));
+                    self.instructions.push(W::I64Const(8));
+                    self.instructions.push(W::I64Mul);
+                    self.instructions.push(W::I64Add);
+                    self.instructions.push(W::I32WrapI64);
+                    self.instructions.push(W::I64Load(3, 0));
+                    self.instructions.push(W::LocalSet(el));
+                    // r = vec_push(r, el)
+                    self.instructions.push(W::LocalGet(rl));
+                    self.instructions.push(W::LocalGet(el));
+                    self.instructions.push(W::Call(rt.vec_push_idx));
+                    self.instructions.push(W::LocalSet(rl));
+                    self.instructions.push(W::LocalGet(iv));
+                    self.instructions.push(W::I64Const(1));
+                    self.instructions.push(W::I64Add);
+                    self.instructions.push(W::LocalSet(iv));
+                    self.instructions.push(W::Br(0));
+                    self.instructions.push(W::End);
+                    self.instructions.push(W::End);
+                    self.instructions.push(W::LocalGet(rl));
+                    return Ok(());
+                }
                 "len" | "count" | "vec-len" => {
                     // Vector length lives at header offset 0.
                     self.compile_expr(&items[1])?;
@@ -2383,9 +2479,12 @@ impl<'a> FnCtx<'a> {
                         ExprKind::Symbol(s) => s.clone(),
                         _ => return Err("let binding must be a symbol".into()),
                     };
-                    // Remember float-typed bindings so later uses pick f64 ops.
+                    // Remember float/string bindings so later uses dispatch.
                     if self.expr_is_float(&items[vi]) {
                         self.float_locals.insert(name.clone());
+                    }
+                    if self.expr_is_string(&items[vi]) {
+                        self.string_locals.insert(name.clone());
                     }
                     self.compile_expr(&items[vi])?;
                     let local = self.alloc_local();
@@ -2963,6 +3062,7 @@ impl<'a> FnCtx<'a> {
             loop_starts: Vec::new(),
             loop_vars: Vec::new(),
             float_locals: std::collections::HashSet::new(),
+            string_locals: std::collections::HashSet::new(),
         };
         cctx.locals.insert("__env_ptr".to_string(), 0);
         for (i, p) in params.iter().enumerate() {
@@ -3456,6 +3556,17 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_split_and_cons_are_valid() {
+        valid(r#"[fn main [] [println [len [split "a b c d" " "]]]]"#);
+        valid(r#"[fn main [] [each [fn [w] [println w]] [split "the quick fox" " "]]]"#);
+        valid(r#"[fn main [] [println [len [cons 1 [cons 2 #[3 4]]]]]]"#);
+    }
+    #[test]
+    fn compile_string_param_equality_is_valid() {
+        // A directly-called fn with string params gets structural `=`.
+        valid(r#"[fn same [a b] [if [= a b] 1 0]] [fn main [] [println [same "xy" [str "x" "y"]]]]"#);
     }
     #[test]
     fn compile_maps_are_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -544,12 +544,16 @@ impl Compiler {
         let its = self.next_fn_idx;
         self.next_fn_idx += 1;
         self.push_function(its, StringRuntime::gen_int_to_str());
+        let lc = self.next_fn_idx;
+        self.next_fn_idx += 1;
+        self.push_function(lc, StringRuntime::gen_lowercase());
         self.string_runtime = Some(StringRuntime {
             str_concat_idx: c,
             str_len_idx: l,
             str_eq_idx: e,
             str_substring_idx: sub,
             int_to_str_idx: its,
+            lowercase_idx: lc,
         });
     }
     fn ensure_collections_runtime(&mut self) {
@@ -964,7 +968,7 @@ impl Compiler {
                 if let ExprKind::Symbol(h) = &items[0].kind {
                     let argc = items.len() - 1;
                     match h.as_str() {
-                        "str" | "str-concat" | "substring" => true,
+                        "str" | "str-concat" | "substring" | "lowercase" => true,
                         "do" => items
                             .last()
                             .is_some_and(|e| Self::is_str_static(e, strs, string_fns)),
@@ -2319,6 +2323,14 @@ impl<'a> FnCtx<'a> {
                     }
                     return Ok(());
                 }
+                "lowercase" => {
+                    self.compiler.ensure_string_runtime();
+                    let rt = self.compiler.string_runtime.clone().unwrap();
+                    self.compile_expr(&items[1])?;
+                    self.instructions
+                        .push(WasmInstruction::Call(rt.lowercase_idx));
+                    return Ok(());
+                }
                 "substring" => {
                     // [substring s start end] -> new packed string.
                     self.compiler.ensure_string_runtime();
@@ -3357,7 +3369,26 @@ impl<'a> FnCtx<'a> {
                 } else if let Some(&l) = self.locals.get(name) {
                     Ok(FnRepr::Closure(l))
                 } else {
-                    Err(format!("codegen: HOF function '{name}' not found"))
+                    // A builtin (or otherwise non-fn symbol) used as a HOF value:
+                    // wrap it in a unary lambda `[fn [g] [name g]]` and compile
+                    // that closure, so e.g. `[map lowercase coll]` works.
+                    let sp = f.span;
+                    let g = "__hof_arg".to_string();
+                    let params = Expr::new(
+                        ExprKind::List(vec![Expr::new(ExprKind::Symbol(g.clone()), sp)]),
+                        sp,
+                    );
+                    let body = Expr::new(
+                        ExprKind::List(vec![
+                            Expr::new(ExprKind::Symbol(name.clone()), sp),
+                            Expr::new(ExprKind::Symbol(g), sp),
+                        ]),
+                        sp,
+                    );
+                    self.compile_closure(&[params, body])?;
+                    let l = self.alloc_local();
+                    self.instructions.push(WasmInstruction::LocalSet(l));
+                    Ok(FnRepr::Closure(l))
                 }
             }
             _ => Err("codegen: HOF requires a function argument".into()),
@@ -3973,6 +4004,12 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_lowercase_and_builtin_hof_are_valid() {
+        valid(r#"[fn main [] [println [lowercase "Hello WORLD"]]]"#);
+        valid(r#"[fn main [] [each [fn [w] [println w]] [map lowercase [split "A B" " "]]]]"#);
+        valid(r#"[fn main [] [each [fn [x] [println x]] [map inc #[1 2 3]]]]"#);
     }
     #[test]
     fn compile_sort_by_is_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -1,4 +1,5 @@
 mod capture;
+mod cps;
 #[allow(clippy::vec_init_then_push)]
 pub mod collections;
 #[allow(clippy::vec_init_then_push)]
@@ -37,7 +38,12 @@ fn infer_node_types(exprs: &[Expr], base_dir: Option<&std::path::Path>) -> HashM
 pub fn compile(exprs: &[Expr]) -> Result<Vec<u8>, String> {
     // Macro expansion phase
     let mut expander = crate::macros::MacroExpander::new();
-    let expanded = expander.expand_program(exprs)?;
+    let mut expanded = expander.expand_program(exprs)?;
+    // Escaping effect handlers: CPS-transform the program first (gated, so other
+    // programs are untouched).
+    if cps::needs_cps(&expanded) {
+        expanded = cps::transform(&expanded);
+    }
 
     let mut compiler = Compiler::new();
     compiler.node_types = infer_node_types(&expanded, None);
@@ -50,7 +56,10 @@ pub fn compile(exprs: &[Expr]) -> Result<Vec<u8>, String> {
 pub fn compile_with_imports(exprs: &[Expr], base_dir: &std::path::Path) -> Result<Vec<u8>, String> {
     // Macro expansion phase
     let mut expander = crate::macros::MacroExpander::new();
-    let expanded = expander.expand_program(exprs)?;
+    let mut expanded = expander.expand_program(exprs)?;
+    if cps::needs_cps(&expanded) {
+        expanded = cps::transform(&expanded);
+    }
 
     let mut compiler = Compiler::new();
     compiler.base_dir = Some(base_dir.to_path_buf());
@@ -4866,6 +4875,23 @@ mod tests {
         assert!(
             wasm_str.contains("read-file"),
             "should contain effect op name"
+        );
+    }
+    #[test]
+    fn compile_escaping_continuations_are_valid() {
+        // Escaping/multi-shot continuations (the State effect): a handler clause
+        // returns a function of state, `resume` is a reified continuation used
+        // non-tail. Compiled via the CPS transform.
+        valid(
+            r#"[effect State [get [] Int] [put [Int] Unit]]
+               [fn run-state [thunk init]
+                 [[handle [thunk]
+                     [return x]    [fn [s] x]
+                     [State.get]   [fn [s] [[resume s] s]]
+                     [State.put n] [fn [s] [[resume 0] n]]]
+                   init]]
+               [fn counter [] [let a [State.get]] [State.put [+ a 1]] [State.get]]
+               [fn main [] [println [run-state counter 0]]]"#,
         );
     }
     #[test]

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -2453,6 +2453,63 @@ impl<'a> FnCtx<'a> {
                     self.instructions.push(WasmInstruction::Call(rt.map_keys_idx));
                     return Ok(());
                 }
+                "take" => {
+                    // [take n v] -> new vector of the first min(n, len) elems.
+                    self.compiler.ensure_collections_runtime();
+                    let rt = self.compiler.collections_runtime.clone().unwrap();
+                    use WasmInstruction as W;
+                    let nl = self.alloc_local();
+                    self.compile_expr(&items[1])?;
+                    self.instructions.push(W::LocalSet(nl));
+                    self.compile_expr(&items[2])?;
+                    let vl = self.alloc_local();
+                    self.instructions.push(W::LocalSet(vl));
+                    let (len, d) = self.emit_vec_header(vl);
+                    // limit = min(n, len)
+                    let lim = self.alloc_local();
+                    self.instructions.push(W::LocalGet(nl));
+                    self.instructions.push(W::LocalGet(len));
+                    self.instructions.push(W::I64LtS);
+                    self.instructions
+                        .push(W::If(BlockType::Result(ValType::I64)));
+                    self.instructions.push(W::LocalGet(nl));
+                    self.instructions.push(W::Else);
+                    self.instructions.push(W::LocalGet(len));
+                    self.instructions.push(W::End);
+                    self.instructions.push(W::LocalSet(lim));
+                    self.instructions.push(W::Call(rt.vec_new_idx));
+                    let rl = self.alloc_local();
+                    self.instructions.push(W::LocalSet(rl));
+                    let iv = self.alloc_local();
+                    self.instructions.push(W::I64Const(0));
+                    self.instructions.push(W::LocalSet(iv));
+                    self.instructions.push(W::Block(BlockType::Empty));
+                    self.instructions.push(W::Loop(BlockType::Empty));
+                    self.instructions.push(W::LocalGet(iv));
+                    self.instructions.push(W::LocalGet(lim));
+                    self.instructions.push(W::I64LtS);
+                    self.instructions.push(W::I32Eqz);
+                    self.instructions.push(W::BrIf(1));
+                    self.instructions.push(W::LocalGet(rl));
+                    self.instructions.push(W::LocalGet(d));
+                    self.instructions.push(W::LocalGet(iv));
+                    self.instructions.push(W::I64Const(8));
+                    self.instructions.push(W::I64Mul);
+                    self.instructions.push(W::I64Add);
+                    self.instructions.push(W::I32WrapI64);
+                    self.instructions.push(W::I64Load(3, 0));
+                    self.instructions.push(W::Call(rt.vec_push_idx));
+                    self.instructions.push(W::LocalSet(rl));
+                    self.instructions.push(W::LocalGet(iv));
+                    self.instructions.push(W::I64Const(1));
+                    self.instructions.push(W::I64Add);
+                    self.instructions.push(W::LocalSet(iv));
+                    self.instructions.push(W::Br(0));
+                    self.instructions.push(W::End);
+                    self.instructions.push(W::End);
+                    self.instructions.push(W::LocalGet(rl));
+                    return Ok(());
+                }
                 "first" => {
                     // first = vec-get v 0
                     self.compiler.ensure_collections_runtime();
@@ -3574,6 +3631,11 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_take_is_valid() {
+        valid(r#"[fn main [] [println [len [take 3 #[10 20 30 40 50]]]]]"#);
+        valid(r#"[fn main [] [println [len [take 9 #[1 2]]]]]"#);
     }
     #[test]
     fn compile_str_stringifies_ints() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -3197,7 +3197,29 @@ impl<'a> FnCtx<'a> {
                 }
             }
         }
-        Err("codegen: unsupported call form".into())
+        // Computed head: the head expression evaluates to a closure value, which
+        // we call through the table (currying / functions returned from calls,
+        // e.g. `[[adder 10] 5]`).
+        {
+            use WasmInstruction as W;
+            let cl = self.alloc_local();
+            self.compile_expr(&items[0])?;
+            self.instructions.push(W::LocalSet(cl));
+            // env = cl & 0xffffffff
+            self.instructions.push(W::LocalGet(cl));
+            self.instructions.push(W::I64Const(0xFFFF_FFFF));
+            self.instructions.push(W::I64And);
+            for arg in &items[1..] {
+                self.compile_expr(arg)?;
+            }
+            self.instructions.push(W::LocalGet(cl));
+            self.instructions.push(W::I64Const(32));
+            self.instructions.push(W::I64ShrU);
+            self.instructions.push(W::I32WrapI64);
+            let ty = self.get_or_create_indirect_type(1 + (items.len() - 1));
+            self.instructions.push(W::CallIndirect(ty));
+            Ok(())
+        }
     }
     /// Compile an effect operation `Effect.op args`. If a matching handler is
     /// installed on the dynamic handler stack at runtime, call it (tail-

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -1681,6 +1681,109 @@ impl<'a> FnCtx<'a> {
         }
         self.instructions.push(W::I64Const(0));
     }
+    /// Emit a WASI fd_write of `len` bytes at memory address `addr` to stdout,
+    /// using the iovec scratch at mem[0..8]. Leaves nothing on the stack.
+    fn emit_fd_write_buf(&mut self, addr: i32, len: i32) {
+        use WasmInstruction as W;
+        self.instructions.push(W::I32Const(0));
+        self.instructions.push(W::I32Const(addr));
+        self.instructions.push(W::I32Store(2, 0));
+        self.instructions.push(W::I32Const(4));
+        self.instructions.push(W::I32Const(len));
+        self.instructions.push(W::I32Store(2, 0));
+        self.instructions.push(W::I32Const(1)); // stdout
+        self.instructions.push(W::I32Const(0)); // iovec
+        self.instructions.push(W::I32Const(1)); // count
+        self.instructions.push(W::I32Const(8)); // nwritten
+        self.instructions.push(W::Call(0));
+        self.instructions.push(W::Drop);
+    }
+    /// Consume an i64 holding f64 bits and print it as `[-]int.dddddd` (six
+    /// fixed fractional digits), optionally with a newline. Leaves UNIT.
+    fn emit_print_f64(&mut self, newline: bool) {
+        use WasmInstruction as W;
+        const FB: i32 = 600; // scratch: '.', six digits, then newline byte
+        let bits = self.alloc_local();
+        let ip = self.alloc_local();
+        let fr = self.alloc_local();
+        let dg = self.alloc_local();
+        self.instructions.push(W::LocalSet(bits));
+        // sign: if fv < 0 { print '-'; fv = -fv }
+        self.instructions.push(W::LocalGet(bits));
+        self.instructions.push(W::F64ReinterpretI64);
+        self.instructions.push(W::F64Const(0.0));
+        self.instructions.push(W::F64Lt);
+        self.instructions.push(W::If(BlockType::Empty));
+        self.instructions.push(W::I32Const(FB));
+        self.instructions.push(W::I32Const(45)); // '-'
+        self.instructions.push(W::I32Store8(0, 0));
+        self.emit_fd_write_buf(FB, 1);
+        self.instructions.push(W::F64Const(0.0));
+        self.instructions.push(W::LocalGet(bits));
+        self.instructions.push(W::F64ReinterpretI64);
+        self.instructions.push(W::F64Sub);
+        self.instructions.push(W::I64ReinterpretF64);
+        self.instructions.push(W::LocalSet(bits));
+        self.instructions.push(W::End);
+        // integer part = trunc(fv); print it with no newline (drop its UNIT).
+        self.instructions.push(W::LocalGet(bits));
+        self.instructions.push(W::F64ReinterpretI64);
+        self.instructions.push(W::I64TruncF64S);
+        self.instructions.push(W::LocalSet(ip));
+        self.instructions.push(W::LocalGet(ip));
+        self.emit_print_i64(false);
+        self.instructions.push(W::Drop);
+        // fractional part = fv - (ip as f64)
+        self.instructions.push(W::LocalGet(bits));
+        self.instructions.push(W::F64ReinterpretI64);
+        self.instructions.push(W::LocalGet(ip));
+        self.instructions.push(W::F64ConvertI64S);
+        self.instructions.push(W::F64Sub);
+        self.instructions.push(W::I64ReinterpretF64);
+        self.instructions.push(W::LocalSet(fr));
+        // buffer[0] = '.'
+        self.instructions.push(W::I32Const(FB));
+        self.instructions.push(W::I32Const(46));
+        self.instructions.push(W::I32Store8(0, 0));
+        // six fractional digits
+        for k in 0..6i32 {
+            // t = frac * 10 ; keep its bits in `fr`
+            self.instructions.push(W::LocalGet(fr));
+            self.instructions.push(W::F64ReinterpretI64);
+            self.instructions.push(W::F64Const(10.0));
+            self.instructions.push(W::F64Mul);
+            self.instructions.push(W::I64ReinterpretF64);
+            self.instructions.push(W::LocalSet(fr));
+            // digit = trunc(t)
+            self.instructions.push(W::LocalGet(fr));
+            self.instructions.push(W::F64ReinterpretI64);
+            self.instructions.push(W::I64TruncF64S);
+            self.instructions.push(W::LocalSet(dg));
+            // buffer[1+k] = '0' + digit
+            self.instructions.push(W::I32Const(FB + 1 + k));
+            self.instructions.push(W::I64Const(48));
+            self.instructions.push(W::LocalGet(dg));
+            self.instructions.push(W::I64Add);
+            self.instructions.push(W::I32WrapI64);
+            self.instructions.push(W::I32Store8(0, 0));
+            // frac = t - digit
+            self.instructions.push(W::LocalGet(fr));
+            self.instructions.push(W::F64ReinterpretI64);
+            self.instructions.push(W::LocalGet(dg));
+            self.instructions.push(W::F64ConvertI64S);
+            self.instructions.push(W::F64Sub);
+            self.instructions.push(W::I64ReinterpretF64);
+            self.instructions.push(W::LocalSet(fr));
+        }
+        self.emit_fd_write_buf(FB, 7); // '.' + 6 digits
+        if newline {
+            self.instructions.push(W::I32Const(FB + 8));
+            self.instructions.push(W::I32Const(10));
+            self.instructions.push(W::I32Store8(0, 0));
+            self.emit_fd_write_buf(FB + 8, 1);
+        }
+        self.instructions.push(W::I64Const(0));
+    }
     /// Whether an expression statically produces a string value. The value
     /// model is untagged (every value is a raw i64), so `println` can only
     /// pick the string-printing path when it can prove the argument is a
@@ -2292,6 +2395,10 @@ impl<'a> FnCtx<'a> {
                             // A computed string (e.g. [str a b], interpolation).
                             self.compile_expr(arg)?;
                             self.emit_print_str(nl);
+                            return Ok(());
+                        } else if self.expr_is_float(arg) {
+                            self.compile_expr(arg)?;
+                            self.emit_print_f64(nl);
                             return Ok(());
                         } else {
                             // A computed (non-literal) argument: evaluate it to
@@ -3217,6 +3324,15 @@ mod tests {
     #[test]
     fn compile_conj_len_are_valid() {
         valid(r#"[fn main [] [println [len [conj [conj #[] 5] 9]]]]"#);
+    }
+    #[test]
+    fn compile_floats_are_valid() {
+        // Float literals, arithmetic, comparison, and println (incl. through a
+        // function body whose param the checker generalizes).
+        valid(r#"[fn main [] [println 3.14] [println [+ 1.5 2.0]]]"#);
+        valid(r#"[fn main [] [println [if [< 1.5 2.5] 1 0]]]"#);
+        valid(r#"[fn area [r] [* [* 3.14 r] r]] [fn main [] [println [area 2.0]]]"#);
+        valid(r#"[fn add [a b] [+ a b]] [fn main [] [println [if [= [add 1.5 2.0] 3.5] 1 0]]]"#);
     }
     #[test]
     fn compile_char_at_is_valid() {

--- a/crates/loon-lang/src/codegen/mod.rs
+++ b/crates/loon-lang/src/codegen/mod.rs
@@ -737,6 +737,21 @@ impl Compiler {
                         "do" => items
                             .last()
                             .is_some_and(|x| Self::is_float_static(x, floats, float_fns)),
+                        "match" if argc >= 3 => {
+                            // Arms are (pat, body) pairs from items[2..]. A
+                            // well-typed match has all arms the same type, so
+                            // any float arm body means the whole match is float
+                            // (this also sees through pattern-bound vars that
+                            // are themselves untracked, e.g. ADT float fields).
+                            let mut i = 3;
+                            while i < items.len() {
+                                if Self::is_float_static(&items[i], floats, float_fns) {
+                                    return true;
+                                }
+                                i += 2;
+                            }
+                            false
+                        }
                         _ => {
                             float_fns.contains(h.as_str())
                                 || float_fns.contains(&format!("{h}#{argc}"))

--- a/crates/loon-lang/src/codegen/strings.rs
+++ b/crates/loon-lang/src/codegen/strings.rs
@@ -22,6 +22,8 @@ pub struct StringRuntime {
     pub str_eq_idx: u32,
     /// WASM function index for str_substring
     pub str_substring_idx: u32,
+    /// WASM function index for int_to_str
+    pub int_to_str_idx: u32,
 }
 
 #[allow(dead_code)]
@@ -297,6 +299,123 @@ impl StringRuntime {
                 ValType::I64, // 6: i
             ],
             instructions: instrs,
+        }
+    }
+
+    /// Generate `int_to_str(n) -> i64` — the decimal text of `n` as a freshly
+    /// allocated packed string. Writes digits backward into a scratch region,
+    /// then copies them into the heap.
+    pub(super) fn gen_int_to_str() -> FunctionBody {
+        const BUF: i64 = 542; // scratch end (digits written backward below it)
+        // Params: 0=n ; Locals: 1=p, 2=neg, 3=len, 4=dst, 5=i
+        let mut i = Vec::new();
+        // neg = n < 0 ; if neg n = -n
+        i.push(LocalGet(0));
+        i.push(I64Const(0));
+        i.push(I64LtS);
+        i.push(If(BlockType::Empty));
+        i.push(I64Const(1));
+        i.push(LocalSet(2));
+        i.push(I64Const(0));
+        i.push(LocalGet(0));
+        i.push(I64Sub);
+        i.push(LocalSet(0));
+        i.push(Else);
+        i.push(I64Const(0));
+        i.push(LocalSet(2));
+        i.push(End);
+        // p = BUF ; do { p--; mem[p] = '0' + n%10; n/=10 } while n != 0
+        i.push(I64Const(BUF));
+        i.push(LocalSet(1));
+        i.push(Loop(BlockType::Empty));
+        i.push(LocalGet(1));
+        i.push(I64Const(1));
+        i.push(I64Sub);
+        i.push(LocalSet(1));
+        i.push(LocalGet(1));
+        i.push(I32WrapI64);
+        i.push(LocalGet(0));
+        i.push(I64Const(10));
+        i.push(I64RemU);
+        i.push(I64Const(48));
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I32Store8(0, 0));
+        i.push(LocalGet(0));
+        i.push(I64Const(10));
+        i.push(I64DivU);
+        i.push(LocalSet(0));
+        i.push(LocalGet(0));
+        i.push(I64Eqz);
+        i.push(I32Eqz);
+        i.push(BrIf(0));
+        i.push(End);
+        // if neg { p--; mem[p] = '-' }
+        i.push(LocalGet(2));
+        i.push(I64Eqz);
+        i.push(I32Eqz);
+        i.push(If(BlockType::Empty));
+        i.push(LocalGet(1));
+        i.push(I64Const(1));
+        i.push(I64Sub);
+        i.push(LocalSet(1));
+        i.push(LocalGet(1));
+        i.push(I32WrapI64);
+        i.push(I32Const(45));
+        i.push(I32Store8(0, 0));
+        i.push(End);
+        // len = BUF - p
+        i.push(I64Const(BUF));
+        i.push(LocalGet(1));
+        i.push(I64Sub);
+        i.push(LocalSet(3));
+        // dst = heap ; heap += len
+        i.push(GlobalGet(0));
+        i.push(I64ExtendI32U);
+        i.push(LocalSet(4));
+        i.push(GlobalGet(0));
+        i.push(LocalGet(3));
+        i.push(I32WrapI64);
+        i.push(I32Add);
+        i.push(GlobalSet(0));
+        // copy: for i in 0..len: mem[dst+i] = mem[p+i]
+        i.push(I64Const(0));
+        i.push(LocalSet(5));
+        i.push(Block(BlockType::Empty));
+        i.push(Loop(BlockType::Empty));
+        i.push(LocalGet(5));
+        i.push(LocalGet(3));
+        i.push(I64LtS);
+        i.push(I32Eqz);
+        i.push(BrIf(1));
+        i.push(LocalGet(4));
+        i.push(LocalGet(5));
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(LocalGet(1));
+        i.push(LocalGet(5));
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I32Load8U(0, 0));
+        i.push(I32Store8(0, 0));
+        i.push(LocalGet(5));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(5));
+        i.push(Br(0));
+        i.push(End);
+        i.push(End);
+        // return (dst << 32) | len
+        i.push(LocalGet(4));
+        i.push(I64Const(32));
+        i.push(I64Shl);
+        i.push(LocalGet(3));
+        i.push(I64Or);
+        FunctionBody {
+            params: vec![ValType::I64],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64; 5],
+            instructions: i,
         }
     }
 

--- a/crates/loon-lang/src/codegen/strings.rs
+++ b/crates/loon-lang/src/codegen/strings.rs
@@ -24,6 +24,8 @@ pub struct StringRuntime {
     pub str_substring_idx: u32,
     /// WASM function index for int_to_str
     pub int_to_str_idx: u32,
+    /// WASM function index for lowercase
+    pub lowercase_idx: u32,
 }
 
 #[allow(dead_code)]
@@ -410,6 +412,87 @@ impl StringRuntime {
         i.push(I64Const(32));
         i.push(I64Shl);
         i.push(LocalGet(3));
+        i.push(I64Or);
+        FunctionBody {
+            params: vec![ValType::I64],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64; 5],
+            instructions: i,
+        }
+    }
+
+    /// Generate `lowercase(s) -> i64` — a fresh packed string with ASCII
+    /// `A`–`Z` lowercased.
+    pub(super) fn gen_lowercase() -> FunctionBody {
+        // Params: 0=s ; Locals: 1=sptr, 2=len, 3=dst, 4=i, 5=b
+        let mut i = Vec::new();
+        i.push(LocalGet(0));
+        i.push(I64Const(32));
+        i.push(I64ShrU);
+        i.push(LocalSet(1));
+        i.push(LocalGet(0));
+        i.push(I64Const(0xFFFF_FFFF));
+        i.push(I64And);
+        i.push(LocalSet(2));
+        // dst = heap ; heap += len
+        i.push(GlobalGet(0));
+        i.push(I64ExtendI32U);
+        i.push(LocalSet(3));
+        i.push(GlobalGet(0));
+        i.push(LocalGet(2));
+        i.push(I32WrapI64);
+        i.push(I32Add);
+        i.push(GlobalSet(0));
+        i.push(I64Const(0));
+        i.push(LocalSet(4));
+        i.push(Block(BlockType::Empty));
+        i.push(Loop(BlockType::Empty));
+        i.push(LocalGet(4));
+        i.push(LocalGet(2));
+        i.push(I64LtS);
+        i.push(I32Eqz);
+        i.push(BrIf(1));
+        // b = mem[sptr + i]
+        i.push(LocalGet(1));
+        i.push(LocalGet(4));
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I32Load8U(0, 0));
+        i.push(I64ExtendI32U);
+        i.push(LocalSet(5));
+        // if 65 <= b <= 90: b += 32
+        i.push(LocalGet(5));
+        i.push(I64Const(65));
+        i.push(I64GeS);
+        i.push(LocalGet(5));
+        i.push(I64Const(90));
+        i.push(I64LeS);
+        i.push(I32And);
+        i.push(If(BlockType::Empty));
+        i.push(LocalGet(5));
+        i.push(I64Const(32));
+        i.push(I64Add);
+        i.push(LocalSet(5));
+        i.push(End);
+        // mem[dst + i] = b
+        i.push(LocalGet(3));
+        i.push(LocalGet(4));
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(LocalGet(5));
+        i.push(I32WrapI64);
+        i.push(I32Store8(0, 0));
+        i.push(LocalGet(4));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(4));
+        i.push(Br(0));
+        i.push(End);
+        i.push(End);
+        i.push(LocalGet(3));
+        i.push(I64Const(32));
+        i.push(I64Shl);
+        i.push(LocalGet(2));
         i.push(I64Or);
         FunctionBody {
             params: vec![ValType::I64],

--- a/crates/loon-lang/src/codegen/strings.rs
+++ b/crates/loon-lang/src/codegen/strings.rs
@@ -300,6 +300,96 @@ impl StringRuntime {
         }
     }
 
+    /// Generate `str_split(s, sep, vec_new, vec_push, substr) -> i64` — split
+    /// `s` on the first byte of `sep`, returning a vector of substrings
+    /// (including empties for adjacent separators). `sep` is treated as a
+    /// single character (the common case, e.g. " ").
+    pub(super) fn gen_str_split(vec_new: u32, vec_push: u32, substr: u32) -> FunctionBody {
+        // Params: 0=s, 1=sep
+        // Locals: 2=sptr, 3=len, 4=sepch, 5=r, 6=start, 7=i, 8=ch
+        let mut i = Vec::new();
+        // sptr = s >> 32
+        i.push(LocalGet(0));
+        i.push(I64Const(32));
+        i.push(I64ShrU);
+        i.push(LocalSet(2));
+        // len = s & 0xffffffff
+        i.push(LocalGet(0));
+        i.push(I64Const(0xFFFF_FFFF));
+        i.push(I64And);
+        i.push(LocalSet(3));
+        // sepch = mem[(sep>>32)]
+        i.push(LocalGet(1));
+        i.push(I64Const(32));
+        i.push(I64ShrU);
+        i.push(I32WrapI64);
+        i.push(I32Load8U(0, 0));
+        i.push(I64ExtendI32U);
+        i.push(LocalSet(4));
+        // r = vec_new()
+        i.push(Call(vec_new));
+        i.push(LocalSet(5));
+        // start = 0; i = 0
+        i.push(I64Const(0));
+        i.push(LocalSet(6));
+        i.push(I64Const(0));
+        i.push(LocalSet(7));
+        i.push(Block(BlockType::Empty));
+        i.push(Loop(BlockType::Empty));
+        // if i >= len break
+        i.push(LocalGet(7));
+        i.push(LocalGet(3));
+        i.push(I64LtS);
+        i.push(I32Eqz);
+        i.push(BrIf(1));
+        // ch = mem[sptr + i]
+        i.push(LocalGet(2));
+        i.push(LocalGet(7));
+        i.push(I64Add);
+        i.push(I32WrapI64);
+        i.push(I32Load8U(0, 0));
+        i.push(I64ExtendI32U);
+        i.push(LocalSet(8));
+        // if ch == sepch: r = vec_push(r, substr(s, start, i)); start = i+1
+        i.push(LocalGet(8));
+        i.push(LocalGet(4));
+        i.push(I64Eq);
+        i.push(If(BlockType::Empty));
+        i.push(LocalGet(5));
+        i.push(LocalGet(0));
+        i.push(LocalGet(6));
+        i.push(LocalGet(7));
+        i.push(Call(substr));
+        i.push(Call(vec_push));
+        i.push(LocalSet(5));
+        i.push(LocalGet(7));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(6));
+        i.push(End);
+        // i++
+        i.push(LocalGet(7));
+        i.push(I64Const(1));
+        i.push(I64Add);
+        i.push(LocalSet(7));
+        i.push(Br(0));
+        i.push(End);
+        i.push(End);
+        // final segment: r = vec_push(r, substr(s, start, len))
+        i.push(LocalGet(5));
+        i.push(LocalGet(0));
+        i.push(LocalGet(6));
+        i.push(LocalGet(3));
+        i.push(Call(substr));
+        i.push(Call(vec_push));
+        FunctionBody {
+            params: vec![ValType::I64, ValType::I64],
+            results: vec![ValType::I64],
+            locals: vec![ValType::I64; 7], // locals 2..=8
+            instructions: i,
+        }
+    }
+
     /// Generate the `str_concat` function body.
     /// Signature: `(a: i64, b: i64) -> i64`
     /// Allocates new string, copies both, returns packed i64.

--- a/crates/loon-lang/tests/codegen_samples.rs
+++ b/crates/loon-lang/tests/codegen_samples.rs
@@ -50,6 +50,7 @@ fn samples_compile_to_valid_wasm() {
         "effects.oo",
         "user-effects.oo",
         "tco-stress.oo",
+        "state.oo",
     ] {
         let bytes = compile_sample(name);
         assert_valid_wasm(name, &bytes);

--- a/crates/loon-lang/tests/codegen_samples.rs
+++ b/crates/loon-lang/tests/codegen_samples.rs
@@ -43,6 +43,7 @@ fn samples_compile_to_valid_wasm() {
         "compiled-fib.oo",
         "pipeline.oo",
         "multi-arity.oo",
+        "types.oo",
     ] {
         let bytes = compile_sample(name);
         assert_valid_wasm(name, &bytes);

--- a/crates/loon-lang/tests/codegen_samples.rs
+++ b/crates/loon-lang/tests/codegen_samples.rs
@@ -44,6 +44,7 @@ fn samples_compile_to_valid_wasm() {
         "pipeline.oo",
         "multi-arity.oo",
         "types.oo",
+        "word-count.oo",
     ] {
         let bytes = compile_sample(name);
         assert_valid_wasm(name, &bytes);

--- a/crates/loon-lang/tests/codegen_samples.rs
+++ b/crates/loon-lang/tests/codegen_samples.rs
@@ -45,6 +45,10 @@ fn samples_compile_to_valid_wasm() {
         "multi-arity.oo",
         "types.oo",
         "word-count.oo",
+        "word-freq.oo",
+        "bench-collections.oo",
+        "effects.oo",
+        "user-effects.oo",
     ] {
         let bytes = compile_sample(name);
         assert_valid_wasm(name, &bytes);

--- a/crates/loon-lang/tests/codegen_samples.rs
+++ b/crates/loon-lang/tests/codegen_samples.rs
@@ -49,6 +49,7 @@ fn samples_compile_to_valid_wasm() {
         "bench-collections.oo",
         "effects.oo",
         "user-effects.oo",
+        "tco-stress.oo",
     ] {
         let bytes = compile_sample(name);
         assert_valid_wasm(name, &bytes);

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -56,6 +56,9 @@ params are float, propagated through call sites. Synthesized nodes (desugared
 - Vectors: `#[…]` literals, `vec-new`/`vec-push`/`conj`/`vec-get`/`len`/`first`/
   `empty?`, and the higher-order functions `range`, `map`, `filter`, `each`,
   `fold` (the function argument may be a lambda literal or a named function).
+- Maps: `{:k v …}` literals and `assoc`/`get`/`contains?`/`keys` — keys
+  compare structurally per their static type (keyword/int by value, **string by
+  content**, incl. computed keys). `split` (one-char separator), `cons`.
 - Keywords (`:foo`), `when`/`unless`/`cond`.
 - `pipe` (thread-last).
 - Multi-arity functions (`[fn f ([x] …) ([x y] …)]`) — each clause is its own
@@ -71,9 +74,16 @@ params are float, propagated through call sites. Synthesized nodes (desugared
   resuming a stack segment needs a whole-program CPS / trampoline transform the
   backend doesn't do. Effect *operations* still compile (to imports); only the
   handlers don't.
-- **Maps / sets** as data (`{…}`, `#{…}` literals and their stdlib), and the
-  string-processing stdlib (`split`, `lowercase`, …). These need polymorphic
-  (string-keyed) equality, which the untagged model can't dispatch yet.
+- **Fully polymorphic values** — when a value's type can't be recovered
+  statically (e.g. a generic accumulator threaded through `fold`, or a
+  heterogeneous collection), codegen can't pick the right comparison/print path.
+  Concretely: a string-keyed map built by a generic function passed to a HOF
+  won't compare keys by content. This is the residue that needs real value
+  **tags** (or full monomorphization); the type-directed pass handles everything
+  whose type is statically evident.
+- **Sets** (`#{…}`) as data, and the rest of the string/seq stdlib
+  (`lowercase`, `sort-by`, `take`, `update`, `entries`, tuple-destructuring
+  lambda params).
 
 These run on the EIR VM, which implements the full language including one-shot
 delimited continuations (see `samples/state.oo`).

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -9,6 +9,11 @@ This is a second backend alongside the EIR VM (`loon run`, the default) and the
 optional Cranelift JIT (`--features native`). It lives in
 `crates/loon-lang/src/codegen/`.
 
+All 16 sample programs (`samples/*.oo`) compile to valid standalone wasm,
+covering the whole language — arithmetic/floats, ADTs, closures + first-class
+functions, strings/maps/vectors and their stdlib, and the full effect system
+(tail-resumptive handlers, abort/`try`, and escaping/multi-shot continuations).
+
 ## Value model
 
 Every value is a raw **i64** (untagged):
@@ -80,24 +85,26 @@ params are float, propagated through call sites. Synthesized nodes (desugared
 - **Abort / `try`**: `Fail.fail v` and `[try expr handler]` lower to the WASM
   exception proposal (a `fail` tag; `throw` / `try_table` catch), so abort
   unwinds correctly across calls — including recursive abort handling.
+- **Escaping / multi-shot continuations** (e.g. the pure `State` effect, where
+  a handler clause returns a function and `resume` is a reified continuation
+  used non-tail): a gated source-to-source **CPS + handler-passing transform**
+  (`codegen/cps.rs`) rewrites such programs into ordinary closures the backend
+  compiles. Continuations become plain closures, so they're multi-shot-capable.
+  Fires only on programs with an escaping handle, so nothing else is affected.
 - Dead-code elimination (`tree_shake`) and a relocating function-index pass so
   imports and `_start` stay correct.
 
-## What does *not* compile yet (use `loon run`)
+## Known limitations
 
-- **Non-tail / escaping / multi-shot continuations** — `resume` used anywhere
-  but tail position, i.e. the continuation reified as a first-class value (the
-  function-returning `State` pattern in `samples/state.oo`, where a handler
-  clause returns `[fn [s] [[resume s] s]]`). This is the one remaining tier and
-  needs reified continuations: a whole-program CPS/trampoline transform, or the
-  wasm stack-switching proposal (unsupported by current runtimes). Tail-resume
-  and abort (above) are the boundary. The VM implements the full set.
-- **Sets** (`#{…}`) as data.
+- **Sets** (`#{…}`) as data are not yet a runtime structure.
 - **Heterogeneous / fully-dynamic values.** The string-vs-pointer
   self-description used for map keys, `empty?`, and `str` covers homogeneous
   data; a genuinely mixed collection (or printing an arbitrary value of unknown
   type) would still need real value **tags**. Almost everything whose type is
   statically evident, or whose runtime shape is self-describing, works today.
+
+All 16 samples compile to valid standalone wasm; this is no longer a
+VM-only-feature boundary but a small set of data-representation edges.
 
 These run on the EIR VM, which implements the full language including one-shot
 delimited continuations (see `samples/state.oo`).

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -51,14 +51,20 @@ params are float, propagated through call sites. Synthesized nodes (desugared
 - ADTs: `[type …]`, constructors, and `match` (int / nullary-ctor / field-binding
   arms, compiled to an if/else chain or a br_table).
 - Closures, including captures, and passing functions as values.
-- Strings: literals, variadic `str`/`str-concat`, `str-len`, `str-eq`,
-  `substring`, `char-at`, and `println` of a computed string (type-directed).
-- Vectors: `#[…]` literals, `vec-new`/`vec-push`/`conj`/`vec-get`/`len`/`first`/
-  `empty?`, and the higher-order functions `range`, `map`, `filter`, `each`,
-  `fold` (the function argument may be a lambda literal or a named function).
-- Maps: `{:k v …}` literals and `assoc`/`get`/`contains?`/`keys` — keys
-  compare structurally per their static type (keyword/int by value, **string by
-  content**, incl. computed keys). `split` (one-char separator), `cons`.
+- Strings: literals, variadic `str`/`str-concat` (which **stringifies non-string
+  args** — type-directed Display via `int_to_str`), `str-len`, `str-eq`,
+  `substring`, `char-at`, `lowercase`, `split`, and `println` of a computed
+  string. Interpolation (`\(expr)` / `fmt`) desugars to `str` at parse time.
+- Vectors: `#[…]` literals, `vec-new`/`vec-push`/`conj`/`cons`/`vec-get`/`len`/
+  `first`/`empty?`/`take`, and the higher-order functions `range`, `map`,
+  `filter`, `each`, `fold`, `sort-by` (the function argument may be a lambda, a
+  named function, or a builtin — the latter two are wrapped automatically).
+- Maps: `{:k v …}` literals and `assoc`/`get`/`update`/`contains?`/`keys`/
+  `entries`/`group-by`. Keys compare **self-describingly** at runtime — raw
+  equality, then string-content compare when both keys look like string pointers
+  — so string-keyed maps work even through generic HOFs (e.g. a `fold`
+  accumulator). `(a b)` tuple literals and tuple-destructuring params
+  (`[fn [[k v]] …]`, `_` wildcard) for both closures and top-level fns.
 - Keywords (`:foo`), `when`/`unless`/`cond`.
 - `pipe` (thread-last).
 - Multi-arity functions (`[fn f ([x] …) ([x y] …)]`) — each clause is its own
@@ -74,16 +80,13 @@ params are float, propagated through call sites. Synthesized nodes (desugared
   resuming a stack segment needs a whole-program CPS / trampoline transform the
   backend doesn't do. Effect *operations* still compile (to imports); only the
   handlers don't.
-- **Fully polymorphic values** — when a value's type can't be recovered
-  statically (e.g. a generic accumulator threaded through `fold`, or a
-  heterogeneous collection), codegen can't pick the right comparison/print path.
-  Concretely: a string-keyed map built by a generic function passed to a HOF
-  won't compare keys by content. This is the residue that needs real value
-  **tags** (or full monomorphization); the type-directed pass handles everything
-  whose type is statically evident.
-- **Sets** (`#{…}`) as data, and the rest of the string/seq stdlib
-  (`lowercase`, `sort-by`, `take`, `update`, `entries`, tuple-destructuring
-  lambda params).
+- **Nested *named* local functions** (`[fn build [..] …]` inside a body) and
+  **sets** (`#{…}`) as data.
+- **Heterogeneous / fully-dynamic values.** The string-vs-pointer
+  self-description used for map keys, `empty?`, and `str` covers homogeneous
+  data; a genuinely mixed collection (or printing an arbitrary value of unknown
+  type) would still need real value **tags**. Almost everything whose type is
+  statically evident, or whose runtime shape is self-describing, works today.
 
 These run on the EIR VM, which implements the full language including one-shot
 delimited continuations (see `samples/state.oo`).

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -75,17 +75,21 @@ params are float, propagated through call sites. Synthesized nodes (desugared
   for the body's dynamic extent; `[resume v]` (in tail position) makes the op
   return `v`. Handlers are dynamically scoped (intercept ops through calls and
   nest correctly).
+- **Abort / `try`**: `Fail.fail v` and `[try expr handler]` lower to the WASM
+  exception proposal (a `fail` tag; `throw` / `try_table` catch), so abort
+  unwinds correctly across calls — including recursive abort handling.
 - Dead-code elimination (`tree_shake`) and a relocating function-index pass so
   imports and `_start` stay correct.
 
 ## What does *not* compile yet (use `loon run`)
 
 - **Non-tail / escaping / multi-shot continuations** — `resume` used anywhere
-  but tail position (the function-returning `State` pattern in
-  `samples/state.oo`), and **abort-style `try`** (`tco-stress.oo`), which needs a
-  non-local exit across calls. The tail-resumptive tier above is the boundary;
-  the rest needs reified continuations (CPS / a trampoline, or wasm exceptions
-  for abort). The VM implements all of these.
+  but tail position, i.e. the continuation reified as a first-class value (the
+  function-returning `State` pattern in `samples/state.oo`, where a handler
+  clause returns `[fn [s] [[resume s] s]]`). This is the one remaining tier and
+  needs reified continuations: a whole-program CPS/trampoline transform, or the
+  wasm stack-switching proposal (unsupported by current runtimes). Tail-resume
+  and abort (above) are the boundary. The VM implements the full set.
 - **Sets** (`#{…}`) as data.
 - **Heterogeneous / fully-dynamic values.** The string-vs-pointer
   self-description used for map keys, `empty?`, and `str` covers homogeneous

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -69,19 +69,24 @@ params are float, propagated through call sites. Synthesized nodes (desugared
 - `pipe` (thread-last).
 - Multi-arity functions (`[fn f ([x] …) ([x y] …)]`) — each clause is its own
   function, resolved by argument count.
-- Effect **operations**: `E.op args` lowers to a host-provided WASM import
-  (`loon:effects/<effect>`); effect-row annotations on functions are ignored.
+- **Effects**: `E.op args` checks a dynamic handler stack first and falls back
+  to a host import (`loon:effects/<effect>`). **Tail-resumptive `handle`**
+  works — `[handle body [E.op p] hbody … [return x] rbody]` installs handlers
+  for the body's dynamic extent; `[resume v]` (in tail position) makes the op
+  return `v`. Handlers are dynamically scoped (intercept ops through calls and
+  nest correctly).
 - Dead-code elimination (`tree_shake`) and a relocating function-index pass so
   imports and `_start` stay correct.
 
 ## What does *not* compile yet (use `loon run`)
 
-- **Delimited continuations** — `handle` / `resume` / `try`. Capturing and
-  resuming a stack segment needs a whole-program CPS / trampoline transform the
-  backend doesn't do. Effect *operations* still compile (to imports); only the
-  handlers don't.
-- **Nested *named* local functions** (`[fn build [..] …]` inside a body) and
-  **sets** (`#{…}`) as data.
+- **Non-tail / escaping / multi-shot continuations** — `resume` used anywhere
+  but tail position (the function-returning `State` pattern in
+  `samples/state.oo`), and **abort-style `try`** (`tco-stress.oo`), which needs a
+  non-local exit across calls. The tail-resumptive tier above is the boundary;
+  the rest needs reified continuations (CPS / a trampoline, or wasm exceptions
+  for abort). The VM implements all of these.
+- **Sets** (`#{…}`) as data.
 - **Heterogeneous / fully-dynamic values.** The string-vs-pointer
   self-description used for map keys, `empty?`, and `str` covers homogeneous
   data; a genuinely mixed collection (or printing an arbitrary value of unknown

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -19,24 +19,44 @@ Every value is a raw **i64** (untagged):
 - Closures are `(table_index << 32) | env_ptr`; the function is reached through
   the funcref table, the captures through `env_ptr`.
 
+Floats are the exception to "everything is an i64": a float value is its f64
+**bit pattern** stored in the i64 slot, reinterpreted to `f64` at each
+arithmetic/comparison op. Whether an op is int or float is **type-directed** —
+codegen consumes the checker's resolved `NodeId → Type` map (see "Type-directed"
+below).
+
 Output goes through WASI `fd_write`. Memory starts at 256 pages (16 MiB) because
 the bump allocator never frees and vectors are copy-on-write.
 
+## Type-directed
+
+The backend runs the type checker over the macro-expanded program and keeps the
+resolved type of every node. This drives decisions the untyped syntax can't:
+`println`/arithmetic dispatch on `Int` vs `Float` vs `Str` from real types, not
+guesses. Where the checker *generalizes* a polymorphic function body (so a body
+node carries a type var rather than a concrete type), a small whole-program
+structural fixpoint recovers which functions return floats / strings and which
+params are float, propagated through call sites. Synthesized nodes (desugared
+`pipe`/`when`/…) fall back to that structural path.
+
 ## What compiles
 
-- Arithmetic & comparison: `+ - * / %`, `> < = != <= >=`, `not and or`.
+- Arithmetic & comparison: `+ - * / %`, `> < = != <= >=`, `not and or` — on
+  both ints and **floats** (literals, arithmetic, comparison, and `println`,
+  including through ADTs/`match` and function bodies).
+- `inc dec abs min max mod`, `print`/`println`.
 - `if`, `do`, `let`, multi-statement function bodies.
 - Recursion, **self-tail-recursion** (`recur` in a `fn` loops back — no stack
   growth), and `loop`/`recur`.
 - ADTs: `[type …]`, constructors, and `match` (int / nullary-ctor / field-binding
   arms, compiled to an if/else chain or a br_table).
 - Closures, including captures, and passing functions as values.
-- Strings: literals, variadic `str`/`str-concat`, `str-len`, `str-eq`, and
-  `println` of a computed string (a fixpoint analysis tracks which functions
-  return strings, since the value model has no runtime tag).
-- Vectors: `#[…]` literals, `vec-new`/`vec-push`/`conj`/`vec-get`/`len`, and the
-  higher-order functions `range`, `map`, `filter`, `each`, `fold` (the function
-  argument may be a lambda literal or a named function).
+- Strings: literals, variadic `str`/`str-concat`, `str-len`, `str-eq`,
+  `substring`, `char-at`, and `println` of a computed string (type-directed).
+- Vectors: `#[…]` literals, `vec-new`/`vec-push`/`conj`/`vec-get`/`len`/`first`/
+  `empty?`, and the higher-order functions `range`, `map`, `filter`, `each`,
+  `fold` (the function argument may be a lambda literal or a named function).
+- Keywords (`:foo`), `when`/`unless`/`cond`.
 - `pipe` (thread-last).
 - Multi-arity functions (`[fn f ([x] …) ([x y] …)]`) — each clause is its own
   function, resolved by argument count.
@@ -51,11 +71,9 @@ the bump allocator never frees and vectors are copy-on-write.
   resuming a stack segment needs a whole-program CPS / trampoline transform the
   backend doesn't do. Effect *operations* still compile (to imports); only the
   handlers don't.
-- **Floats** — arithmetic assumes i64 operands, so float programs currently
-  produce a module the validator rejects. Proper support needs a tagged or
-  type-directed value model.
 - **Maps / sets** as data (`{…}`, `#{…}` literals and their stdlib), and the
-  string-processing stdlib (`split`, `lowercase`, …).
+  string-processing stdlib (`split`, `lowercase`, …). These need polymorphic
+  (string-keyed) equality, which the untagged model can't dispatch yet.
 
 These run on the EIR VM, which implements the full language including one-shot
 delimited continuations (see `samples/state.oo`).

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -50,7 +50,9 @@ params are float, propagated through call sites. Synthesized nodes (desugared
   growth), and `loop`/`recur`.
 - ADTs: `[type …]`, constructors, and `match` (int / nullary-ctor / field-binding
   arms, compiled to an if/else chain or a br_table).
-- Closures, including captures, and passing functions as values.
+- Closures (with captures); **first-class functions** — a bare top-level
+  function name is a value, and a computed function value can be applied
+  (`[[adder 10] 5]`, currying / functions returned from calls).
 - Strings: literals, variadic `str`/`str-concat` (which **stringifies non-string
   args** — type-directed Display via `int_to_str`), `str-len`, `str-eq`,
   `substring`, `char-at`, `lowercase`, `split`, and `println` of a computed


### PR DESCRIPTION
## Summary

This PR extends the WASM backend with two major features:

1. **Insertion-ordered map support** — a complete runtime implementation of maps as heap structures with copy-on-write semantics, including self-describing key equality that works for string keys even through generic code.

2. **CPS + handler-passing transform for escaping effect handlers** — a source-to-source transformation that converts programs using escaping handlers (where handler clauses return functions) into ordinary Loon with closures and first-class calls, enabling multi-shot continuations.

## Key Changes

- **`crates/loon-lang/src/codegen/maps.rs`** (new, 561 lines)
  - Map runtime helpers: `map_new`, `map_set`, `map_get`, `map_has`, `map_keys`, `map_entries`, `map_merge`
  - Self-describing key equality (`emit_key_eq`) that detects string pointers by range check on high-32 bits and compares by content when both keys are strings
  - Copy-on-write semantics matching vector behavior
  - Uses global 0 as bump allocator

- **`crates/loon-lang/src/codegen/cps.rs`** (new, 535 lines)
  - Source-to-source CPS transformation for escaping handlers
  - Threads two extra arguments through effectful functions: `k` (delimited continuation) and `h` (handler dispatcher)
  - Converts handler clauses that return functions into ordinary closures
  - Enables multi-shot continuations while keeping tail-resumptive and abort handlers in the backend

- **`crates/loon-lang/src/codegen/strings.rs`** (modified)
  - Added `int_to_str` function to convert integers to decimal string representation
  - Added `lowercase` function for string case conversion
  - Both allocate freshly on the heap using the bump allocator

- **`crates/loon-lang/src/codegen/mod.rs`** (modified, +1981/-168 lines)
  - Integrated map and CPS support into the main codegen pipeline
  - Updated to call CPS transform when escaping handlers are detected
  - Wired up new string runtime functions

- **`docs/codegen.md`** (modified)
  - Updated documentation to reflect that all 16 sample programs now compile to valid standalone WASM
  - Clarified float handling as bit patterns with type-directed operations
  - Expanded value model documentation

- **`crates/loon-lang/tests/codegen_samples.rs`** (modified)
  - Added test coverage for new sample programs: `types.oo`, `word-count.oo`, `word-freq.oo`, `bench-collections.oo`

## Notable Implementation Details

- **Self-describing key equality**: Rather than requiring a compile-time type flag, keys are compared by checking if their high-32 bits fall in the heap range `[1024, heap_ptr)`. This allows string keys to work transparently even through generic higher-order function code (e.g., `fold` with unknown key type).

- **CPS continuation reification**: Continuations are materialized as closures only when needed (e.g., when shared between multiple code paths), reducing closure allocation overhead.

- **Scratch buffer for int-to-str**: Uses a fixed scratch region (ending at byte 542) to write digits backward, then copies the result into the heap, avoiding dynamic allocation during conversion.

https://claude.ai/code/session_01NBCUByr2VZqDvqAD7eDHus